### PR TITLE
Refactor analytics charts

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -11,19 +11,10 @@ import {
 } from "../components/ui/card";
 import { db } from "../db";
 import type { Session, PathItem, Flow } from "../types/flow";
-import {
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  Cell,
-} from "recharts";
+import TotalTimeChart from "./Analytics/TotalTimeChart";
+import TimelineChart from "./Analytics/TimelineChart";
+import Heatmap from "./Analytics/Heatmap";
+import StackedAreaChart from "./Analytics/StackedAreaChart";
 
 interface SessionRun {
   sessionId: string;
@@ -234,208 +225,16 @@ export default function Analytics() {
         </div>
 
         {/* Bar Chart - Total Time per Step */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg sm:text-xl">
-              Tempo total por passo (s)
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-64 w-full sm:h-80 lg:h-96">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart
-                  data={totalByStepData}
-                  margin={{
-                    top: 20,
-                    right: 20,
-                    bottom: window.innerWidth < 640 ? 80 : 60,
-                    left: 20,
-                  }}
-                >
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis
-                    dataKey="name"
-                    angle={window.innerWidth < 640 ? -45 : -30}
-                    textAnchor="end"
-                    height={window.innerWidth < 640 ? 80 : 60}
-                    fontSize={window.innerWidth < 640 ? 10 : 12}
-                    interval={0}
-                  />
-                  <YAxis
-                    unit="s"
-                    fontSize={window.innerWidth < 640 ? 10 : 12}
-                  />
-                  <Tooltip formatter={(v: number) => `${v.toFixed(1)} s`} />
-                  <Legend />
-                  <Bar dataKey="totalTime">
-                    {totalByStepData.map((entry, idx) => (
-                      <Cell key={idx} fill={entry.color} />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
+        <TotalTimeChart data={totalByStepData} />
 
         {/* Timeline Horizontal */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg sm:text-xl">
-              Timeline – Últimas 5 Execuções
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-48 w-full sm:h-64 lg:h-80">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart
-                  data={timelineData}
-                  layout="vertical"
-                  margin={{
-                    left: window.innerWidth < 640 ? 60 : 80,
-                    right: 20,
-                    top: 20,
-                    bottom: 20,
-                  }}
-                >
-                  <XAxis
-                    type="number"
-                    unit="s"
-                    fontSize={window.innerWidth < 640 ? 10 : 12}
-                  />
-                  <YAxis
-                    type="category"
-                    dataKey="name"
-                    width={window.innerWidth < 640 ? 60 : 100}
-                    fontSize={window.innerWidth < 640 ? 9 : 11}
-                  />
-                  <Tooltip formatter={(v: number) => `${v}s`} />
-                  <Legend />
-                  {stepTitles.map((title, idx) => (
-                    <Bar
-                      key={title}
-                      dataKey={title}
-                      stackId="a"
-                      fill={COLORS[idx % COLORS.length]}
-                    />
-                  ))}
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
+        <TimelineChart data={timelineData} stepTitles={stepTitles} colors={COLORS} />
 
         {/* Heatmap */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg sm:text-xl">
-              Heatmap de Tempo
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <div className="min-w-full">
-                <table className="w-full border-collapse text-xs sm:text-sm">
-                  <thead>
-                    <tr>
-                      <th className="border bg-gray-50 p-2 text-left font-medium sm:p-3">
-                        Sessão
-                      </th>
-                      {stepTitles.map((t) => (
-                        <th
-                          key={t}
-                          className="border bg-gray-50 p-2 text-center font-medium sm:p-3"
-                          style={{ minWidth: "80px" }}
-                        >
-                          <div className="truncate" title={t}>
-                            {t}
-                          </div>
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {recentRuns.map((run, i) => {
-                      const map = Object.fromEntries(
-                        run.path.map((p) => [p.title, p.timeSpent])
-                      );
-                      return (
-                        <tr key={i}>
-                          <td className="border p-2 font-medium sm:p-3">
-                            #{i + 1}
-                          </td>
-                          {stepTitles.map((t, j) => {
-                            const v = map[t] ?? 0;
-                            const alpha = v ? 0.3 + 0.7 * (v / allDur) : 0;
-                            const bg = v
-                              ? `rgba(59,130,246,${alpha})`
-                              : "#f3f4f6";
-                            return (
-                              <td
-                                key={j}
-                                className="border p-2 text-center sm:p-3"
-                                style={{ backgroundColor: bg }}
-                              >
-                                {v ? Math.round(v) : "–"}
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <Heatmap recentRuns={recentRuns} stepTitles={stepTitles} maxDuration={allDur} />
 
         {/* Stacked Area Chart */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg sm:text-xl">
-              Área Empilhada – Últimas 5
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-56 w-full sm:h-72 lg:h-80">
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart
-                  data={areaData}
-                  margin={{
-                    top: 20,
-                    right: 20,
-                    left: 20,
-                    bottom: 20,
-                  }}
-                >
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis
-                    dataKey="name"
-                    fontSize={window.innerWidth < 640 ? 10 : 12}
-                  />
-                  <YAxis
-                    unit="s"
-                    fontSize={window.innerWidth < 640 ? 10 : 12}
-                  />
-                  <Tooltip formatter={(v: number) => `${v}s`} />
-                  <Legend />
-                  {stepTitles.map((title, idx) => (
-                    <Area
-                      key={title}
-                      type="monotone"
-                      dataKey={title}
-                      stackId="1"
-                      stroke={COLORS[idx % COLORS.length]}
-                      fill={COLORS[idx % COLORS.length]}
-                      fillOpacity={0.6}
-                    />
-                  ))}
-                </AreaChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
+        <StackedAreaChart data={areaData} stepTitles={stepTitles} colors={COLORS} />
       </div>
     </div>
   );

--- a/src/pages/Analytics/Heatmap.tsx
+++ b/src/pages/Analytics/Heatmap.tsx
@@ -1,0 +1,64 @@
+import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
+import type { PathItem } from "../../types/flow";
+
+interface SessionRun {
+  path: PathItem[];
+}
+
+interface Props {
+  recentRuns: SessionRun[];
+  stepTitles: string[];
+  maxDuration: number;
+}
+
+export default function Heatmap({ recentRuns, stepTitles, maxDuration }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg sm:text-xl">Heatmap de Tempo</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <div className="min-w-full">
+            <table className="w-full border-collapse text-xs sm:text-sm">
+              <thead>
+                <tr>
+                  <th className="border bg-gray-50 p-2 text-left font-medium sm:p-3">Sessão</th>
+                  {stepTitles.map((t) => (
+                    <th
+                      key={t}
+                      className="border bg-gray-50 p-2 text-center font-medium sm:p-3"
+                      style={{ minWidth: "80px" }}
+                    >
+                      <div className="truncate" title={t}>{t}</div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {recentRuns.map((run, i) => {
+                  const map = Object.fromEntries(run.path.map((p) => [p.title, p.timeSpent]));
+                  return (
+                    <tr key={i}>
+                      <td className="border p-2 font-medium sm:p-3">#{i + 1}</td>
+                      {stepTitles.map((t, j) => {
+                        const v = map[t] ?? 0;
+                        const alpha = v ? 0.3 + 0.7 * (v / maxDuration) : 0;
+                        const bg = v ? `rgba(59,130,246,${alpha})` : "#f3f4f6";
+                        return (
+                          <td key={j} className="border p-2 text-center sm:p-3" style={{ backgroundColor: bg }}>
+                            {v ? Math.round(v) : "–"}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/Analytics/StackedAreaChart.tsx
+++ b/src/pages/Analytics/StackedAreaChart.tsx
@@ -1,0 +1,45 @@
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
+
+interface Props {
+  data: any[];
+  stepTitles: string[];
+  colors: string[];
+}
+
+export default function StackedAreaChart({ data, stepTitles, colors }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg sm:text-xl">Área Empilhada – Últimas 5</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-56 w-full sm:h-72 lg:h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={data}
+              margin={{ top: 20, right: 20, left: 20, bottom: 20 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" fontSize={window.innerWidth < 640 ? 10 : 12} />
+              <YAxis unit="s" fontSize={window.innerWidth < 640 ? 10 : 12} />
+              <Tooltip formatter={(v: number) => `${v}s`} />
+              <Legend />
+              {stepTitles.map((title, idx) => (
+                <Area
+                  key={title}
+                  type="monotone"
+                  dataKey={title}
+                  stackId="1"
+                  stroke={colors[idx % colors.length]}
+                  fill={colors[idx % colors.length]}
+                  fillOpacity={0.6}
+                />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/Analytics/TimelineChart.tsx
+++ b/src/pages/Analytics/TimelineChart.tsx
@@ -1,0 +1,47 @@
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
+
+interface Props {
+  data: any[];
+  stepTitles: string[];
+  colors: string[];
+}
+
+export default function TimelineChart({ data, stepTitles, colors }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg sm:text-xl">Timeline – Últimas 5 Execuções</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-48 w-full sm:h-64 lg:h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{
+                left: window.innerWidth < 640 ? 60 : 80,
+                right: 20,
+                top: 20,
+                bottom: 20,
+              }}
+            >
+              <XAxis type="number" unit="s" fontSize={window.innerWidth < 640 ? 10 : 12} />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={window.innerWidth < 640 ? 60 : 100}
+                fontSize={window.innerWidth < 640 ? 9 : 11}
+              />
+              <Tooltip formatter={(v: number) => `${v}s`} />
+              <Legend />
+              {stepTitles.map((title, idx) => (
+                <Bar key={title} dataKey={title} stackId="a" fill={colors[idx % colors.length]} />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/Analytics/TotalTimeChart.tsx
+++ b/src/pages/Analytics/TotalTimeChart.tsx
@@ -1,0 +1,55 @@
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Cell } from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
+
+interface DataItem {
+  name: string;
+  totalTime: number;
+  color: string;
+}
+
+interface Props {
+  data: DataItem[];
+}
+
+export default function TotalTimeChart({ data }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg sm:text-xl">Tempo total por passo (s)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-64 w-full sm:h-80 lg:h-96">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={data}
+              margin={{
+                top: 20,
+                right: 20,
+                bottom: window.innerWidth < 640 ? 80 : 60,
+                left: 20,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="name"
+                angle={window.innerWidth < 640 ? -45 : -30}
+                textAnchor="end"
+                height={window.innerWidth < 640 ? 80 : 60}
+                fontSize={window.innerWidth < 640 ? 10 : 12}
+                interval={0}
+              />
+              <YAxis unit="s" fontSize={window.innerWidth < 640 ? 10 : 12} />
+              <Tooltip formatter={(v: number) => `${v.toFixed(1)} s`} />
+              <Legend />
+              <Bar dataKey="totalTime">
+                {data.map((entry, idx) => (
+                  <Cell key={idx} fill={entry.color} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- split analytics charts into separate files under `src/pages/Analytics`
- simplify `Analytics.tsx` by using the new chart components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869e723ce9c83229913e5441d308dc4