### PR TITLE
Fix per-step analytics charts

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -119,20 +119,20 @@ export default function Analytics() {
     }
   );
 
-  const stepTitles = f.steps.map((s) => s.title);
+  const steps = f.steps.map((s) => ({ id: s.id, title: s.title }));
   const timelineData = recentRuns.map((run, idx) => {
     const row: any = { name: `Sessão #${idx + 1}` };
-    run.path.forEach((p) => (row[p.title] = +(p.timeSpent / 1000).toFixed(1)));
+    run.path.forEach((p) => (row[p.id] = +(p.timeSpent / 1000).toFixed(1)));
     return row;
   });
 
   const allDur = recentRuns
-    .flatMap((r) => r.path.map((p) => p.timeSpent))
+    .flatMap((r) => r.path.map((p) => p.timeSpent / 1000))
     .reduce((mx, v) => (v > mx ? v : mx), 0);
 
   const areaData = recentRuns.map((run, idx) => {
     const row: any = { name: `#${idx + 1}` };
-    run.path.forEach((p) => (row[p.title] = +(p.timeSpent / 1000).toFixed(1)));
+    run.path.forEach((p) => (row[p.id] = +(p.timeSpent / 1000).toFixed(1)));
     return row;
   });
 
@@ -228,13 +228,13 @@ export default function Analytics() {
         <TotalTimeChart data={totalByStepData} />
 
         {/* Timeline Horizontal */}
-        <TimelineChart data={timelineData} stepTitles={stepTitles} colors={COLORS} />
+        <TimelineChart data={timelineData} steps={steps} colors={COLORS} />
 
         {/* Heatmap */}
-        <Heatmap recentRuns={recentRuns} stepTitles={stepTitles} maxDuration={allDur} />
+        <Heatmap recentRuns={recentRuns} steps={steps} maxDuration={allDur} />
 
         {/* Stacked Area Chart */}
-        <StackedAreaChart data={areaData} stepTitles={stepTitles} colors={COLORS} />
+        <StackedAreaChart data={areaData} steps={steps} colors={COLORS} />
       </div>
     </div>
   );

--- a/src/pages/Analytics/Heatmap.tsx
+++ b/src/pages/Analytics/Heatmap.tsx
@@ -5,13 +5,18 @@ interface SessionRun {
   path: PathItem[];
 }
 
+interface StepInfo {
+  id: string;
+  title: string;
+}
+
 interface Props {
   recentRuns: SessionRun[];
-  stepTitles: string[];
+  steps: StepInfo[];
   maxDuration: number;
 }
 
-export default function Heatmap({ recentRuns, stepTitles, maxDuration }: Props) {
+export default function Heatmap({ recentRuns, steps, maxDuration }: Props) {
   return (
     <Card>
       <CardHeader>
@@ -24,25 +29,27 @@ export default function Heatmap({ recentRuns, stepTitles, maxDuration }: Props) 
               <thead>
                 <tr>
                   <th className="border bg-gray-50 p-2 text-left font-medium sm:p-3">Sessão</th>
-                  {stepTitles.map((t) => (
+                  {steps.map((s) => (
                     <th
-                      key={t}
+                      key={s.id}
                       className="border bg-gray-50 p-2 text-center font-medium sm:p-3"
                       style={{ minWidth: "80px" }}
                     >
-                      <div className="truncate" title={t}>{t}</div>
+                      <div className="truncate" title={s.title}>{s.title}</div>
                     </th>
                   ))}
                 </tr>
               </thead>
               <tbody>
                 {recentRuns.map((run, i) => {
-                  const map = Object.fromEntries(run.path.map((p) => [p.title, p.timeSpent]));
+                  const map = Object.fromEntries(
+                    run.path.map((p) => [p.id, p.timeSpent / 1000])
+                  );
                   return (
                     <tr key={i}>
                       <td className="border p-2 font-medium sm:p-3">#{i + 1}</td>
-                      {stepTitles.map((t, j) => {
-                        const v = map[t] ?? 0;
+                      {steps.map((s, j) => {
+                        const v = map[s.id] ?? 0;
                         const alpha = v ? 0.3 + 0.7 * (v / maxDuration) : 0;
                         const bg = v ? `rgba(59,130,246,${alpha})` : "#f3f4f6";
                         return (

--- a/src/pages/Analytics/StackedAreaChart.tsx
+++ b/src/pages/Analytics/StackedAreaChart.tsx
@@ -1,13 +1,18 @@
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
 
+interface StepInfo {
+  id: string;
+  title: string;
+}
+
 interface Props {
   data: any[];
-  stepTitles: string[];
+  steps: StepInfo[];
   colors: string[];
 }
 
-export default function StackedAreaChart({ data, stepTitles, colors }: Props) {
+export default function StackedAreaChart({ data, steps, colors }: Props) {
   return (
     <Card>
       <CardHeader>
@@ -25,11 +30,12 @@ export default function StackedAreaChart({ data, stepTitles, colors }: Props) {
               <YAxis unit="s" fontSize={window.innerWidth < 640 ? 10 : 12} />
               <Tooltip formatter={(v: number) => `${v}s`} />
               <Legend />
-              {stepTitles.map((title, idx) => (
+              {steps.map((step, idx) => (
                 <Area
-                  key={title}
+                  key={step.id}
                   type="monotone"
-                  dataKey={title}
+                  dataKey={step.id}
+                  name={step.title}
                   stackId="1"
                   stroke={colors[idx % colors.length]}
                   fill={colors[idx % colors.length]}

--- a/src/pages/Analytics/TimelineChart.tsx
+++ b/src/pages/Analytics/TimelineChart.tsx
@@ -1,13 +1,18 @@
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
 
+interface StepInfo {
+  id: string;
+  title: string;
+}
+
 interface Props {
   data: any[];
-  stepTitles: string[];
+  steps: StepInfo[];
   colors: string[];
 }
 
-export default function TimelineChart({ data, stepTitles, colors }: Props) {
+export default function TimelineChart({ data, steps, colors }: Props) {
   return (
     <Card>
       <CardHeader>
@@ -35,8 +40,14 @@ export default function TimelineChart({ data, stepTitles, colors }: Props) {
               />
               <Tooltip formatter={(v: number) => `${v}s`} />
               <Legend />
-              {stepTitles.map((title, idx) => (
-                <Bar key={title} dataKey={title} stackId="a" fill={colors[idx % colors.length]} />
+              {steps.map((step, idx) => (
+                <Bar
+                  key={step.id}
+                  dataKey={step.id}
+                  name={step.title}
+                  stackId="a"
+                  fill={colors[idx % colors.length]}
+                />
               ))}
             </BarChart>
           </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- fix step identification in analytics charts
- update Timeline, Heatmap and Stacked Area charts to use step IDs
- build chart data using step IDs in `Analytics`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules and declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6869e8ca0c5083228850a71dfe3ea77f