### PR TITLE
Add pause/resume feature with analytics heatmap

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,12 @@
 import Dexie from "dexie";
 import type { Table } from "dexie";
-import type { Flow, LogEntry, Session, StepEvent } from "../types/flow";
+import type { Flow, LogEntry, Session, StepEvent, PauseEvent } from "../types/flow";
 
 class TacoDB extends Dexie {
   flows!: Table<Flow, string>;
   sessions!: Table<Session, string>;
   stepEvents!: Table<StepEvent, string>;
+  pauseEvents!: Table<PauseEvent, string>;
   logs!: Table<LogEntry, string>;
 
   constructor() {
@@ -15,6 +16,7 @@ class TacoDB extends Dexie {
       flows: "id, title, status, updatedAt",
       sessions: "id, flowId, startedAt, finishedAt",
       stepEvents: "id, sessionId, stepId, enterAt, leaveAt",
+      pauseEvents: "id, sessionId, stepId, pausedAt, resumedAt",
       logs: "id, ts, actor, action, flowId, stepId",
     });
   }

--- a/src/pages/Analytics/PauseHeatmap.tsx
+++ b/src/pages/Analytics/PauseHeatmap.tsx
@@ -1,0 +1,65 @@
+import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
+
+interface PauseRun {
+  counts: Record<string, number>;
+}
+
+interface StepInfo {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  pauseRuns: PauseRun[];
+  steps: StepInfo[];
+  maxCount: number;
+}
+
+export default function PauseHeatmap({ pauseRuns, steps, maxCount }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg sm:text-xl">Heatmap de Pausas</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <div className="min-w-full">
+            <table className="w-full border-collapse text-xs sm:text-sm">
+              <thead>
+                <tr>
+                  <th className="border bg-gray-50 p-2 text-left font-medium sm:p-3">Sessão</th>
+                  {steps.map((s) => (
+                    <th
+                      key={s.id}
+                      className="border bg-gray-50 p-2 text-center font-medium sm:p-3"
+                      style={{ minWidth: "80px" }}
+                    >
+                      <div className="truncate" title={s.title}>{s.title}</div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {pauseRuns.map((run, i) => (
+                  <tr key={i}>
+                    <td className="border p-2 font-medium sm:p-3">#{i + 1}</td>
+                    {steps.map((s, j) => {
+                      const v = run.counts[s.id] ?? 0;
+                      const alpha = v ? 0.3 + 0.7 * (v / maxCount) : 0;
+                      const bg = v ? `rgba(59,130,246,${alpha})` : "#f3f4f6";
+                      return (
+                        <td key={j} className="border p-2 text-center sm:p-3" style={{ backgroundColor: bg }}>
+                          {v || "–"}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -74,6 +74,18 @@ export interface StepEvent {
 }
 
 /**
+ * Evento de pausa/resumo de um Step dentro de uma sessão.
+ * Usado para calcular o número de pausas.
+ */
+export interface PauseEvent {
+  id: string;
+  sessionId: string;
+  stepId: string;
+  pausedAt: number;
+  resumedAt?: number;
+}
+
+/**
  * Log de ações importantes (CRUD, erros, conflitos, etc.).
  */
 export interface LogEntry {


### PR DESCRIPTION
## Summary
- implement pause/resume support in player hook
- display Pause/Resume button and paused timer in `FlowPlayer`
- track pause events in database
- new pause heatmap on analytics page
- expose `PauseEvent` type
- consolidate Dexie schema into a single version

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6869eae0815483228ccd0cd1b9eac805