### PR TITLE
Fix select item none value

### DIFF
--- a/src/components/flow/StepForm.tsx
+++ b/src/components/flow/StepForm.tsx
@@ -74,6 +74,8 @@ const STEP_TYPES = [
   },
 ] as const;
 
+const NO_TARGET_STEP_VALUE = "__NONE__";
+
 export default function StepForm({ step, steps, onChange, onDelete }: Props) {
   const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -434,14 +436,21 @@ function OptionItem({ option, index, steps, onUpdate, onRemove }: OptionItemProp
             className="text-sm"
           />
           <Select
-            value={option.targetStepId}
-            onValueChange={(value) => onUpdate("targetStepId", value)}
+            value={
+              option.targetStepId === "" ? NO_TARGET_STEP_VALUE : option.targetStepId
+            }
+            onValueChange={(value) =>
+              onUpdate(
+                "targetStepId",
+                value === NO_TARGET_STEP_VALUE ? "" : value
+              )
+            }
           >
             <SelectTrigger>
               <SelectValue placeholder="Próximo passo (opcional)" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">Nenhum</SelectItem>
+              <SelectItem value={NO_TARGET_STEP_VALUE}>Nenhum</SelectItem>
               {steps.map((s) => (
                 <SelectItem key={s.id} value={s.id}>
                   {s.order + 1}. {s.title}


### PR DESCRIPTION
## Summary
- fix StepForm to use non-empty value for Radix Select `Nenhum`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6869fda5a7288322b604bde0ecee2704