### PR TITLE
Add console audit logging

### DIFF
--- a/src/utils/audit.ts
+++ b/src/utils/audit.ts
@@ -21,6 +21,7 @@ export async function logAction(
     };
 
     await db.logs.add(entry);
+    console.log("[Audit] log saved:", entry);
 
     // Mantém apenas os últimos 1000 logs para evitar crescimento excessivo
     const count = await db.logs.count();


### PR DESCRIPTION
## Summary
- log audit entries to the console after persisting them

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'lucide-react')*

------
https://chatgpt.com/codex/tasks/task_e_686a017c6bb0832294abaf7f40f1d577