### PR TITLE
Implement dynamic network graph

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -278,7 +278,7 @@ export default function Analytics() {
         <StackedAreaChart data={areaData} steps={steps} colors={COLORS} />
 
         {/* Network Graph */}
-        <NetworkGraph />
+        <NetworkGraph flow={f} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- compute transitions from session paths
- render network graph based on real flow data
- display connection thickness according to transition counts

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find modules during tsc)*

------
https://chatgpt.com/codex/tasks/task_e_686a025a058483229579881d141709ad