### PR TITLE
Add analytics PDF export button

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -201,6 +201,14 @@ export default function Analytics() {
                 >
                   Limpar Métricas
                 </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => window.print()}
+                  className="w-full sm:w-auto"
+                >
+                  Exportar Relatório
+                </Button>
               </div>
             </div>
           </CardHeader>


### PR DESCRIPTION
## Summary
- add an "Exportar Relatório" button to the Analytics page that calls `window.print()`

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686a03fdc0a48322a2b8f3b3d34fc80f