### PR TITLE
Hide action buttons in analytics print view

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -184,7 +184,7 @@ export default function Analytics() {
               <CardTitle className="text-xl sm:text-2xl lg:text-3xl">
                 Analytics: {f.title}
               </CardTitle>
-              <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="flex flex-col gap-2 sm:flex-row print:hidden">
                 <Button
                   size="sm"
                   variant="secondary"


### PR DESCRIPTION
## Summary
- update analytics screen to hide action buttons while printing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'lucide-react')*

------
https://chatgpt.com/codex/tasks/task_e_686a05998e348322bb4097452852e1b3