### PR TITLE
Add reusable custom components

### DIFF
--- a/src/components/CustomRenderer.tsx
+++ b/src/components/CustomRenderer.tsx
@@ -1,0 +1,51 @@
+import DOMPurify from "dompurify";
+
+interface Props {
+  html: string;
+  css: string;
+  js: string;
+}
+
+export default function CustomRenderer({ html, css, js }: Props) {
+  const srcDoc = `
+    <html>
+      <head>
+        <style>${DOMPurify.sanitize(css, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })}</style>
+      </head>
+      <body>
+        ${DOMPurify.sanitize(html, {
+          ALLOWED_TAGS: [
+            "div",
+            "span",
+            "p",
+            "ul",
+            "li",
+            "a",
+            "input",
+            "label",
+          ],
+          ALLOWED_ATTR: [
+            "href",
+            "target",
+            "rel",
+            "class",
+            "style",
+            "checked",
+            "readonly",
+          ],
+        })}
+        <script>
+          ${js}
+        </script>
+      </body>
+    </html>
+  `;
+
+  return (
+    <iframe
+      sandbox="allow-scripts allow-popups"
+      srcDoc={srcDoc}
+      style={{ width: "100%", height: "200px", border: "none" }}
+    />
+  );
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,6 @@
 import Dexie from "dexie";
 import type { Table } from "dexie";
-import type { Flow, LogEntry, Session, StepEvent, PauseEvent } from "../types/flow";
+import type { Flow, LogEntry, Session, StepEvent, PauseEvent, CustomComponent } from "../types/flow";
 
 class TacoDB extends Dexie {
   flows!: Table<Flow, string>;
@@ -8,6 +8,7 @@ class TacoDB extends Dexie {
   stepEvents!: Table<StepEvent, string>;
   pauseEvents!: Table<PauseEvent, string>;
   logs!: Table<LogEntry, string>;
+  customComponents!: Table<CustomComponent, string>;
 
   constructor() {
     super("taco");
@@ -18,6 +19,15 @@ class TacoDB extends Dexie {
       stepEvents: "id, sessionId, stepId, enterAt, leaveAt",
       pauseEvents: "id, sessionId, stepId, pausedAt, resumedAt",
       logs: "id, ts, actor, action, flowId, stepId",
+    });
+
+    this.version(2).stores({
+      flows: "id, title, status, updatedAt",
+      sessions: "id, flowId, startedAt, finishedAt",
+      stepEvents: "id, sessionId, stepId, enterAt, leaveAt",
+      pauseEvents: "id, sessionId, stepId, pausedAt, resumedAt",
+      logs: "id, ts, actor, action, flowId, stepId",
+      customComponents: "id, name",
     });
   }
 }

--- a/src/hooks/useCustomComponents.ts
+++ b/src/hooks/useCustomComponents.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { nanoid } from "nanoid";
+import type { CustomComponent } from "../types/flow";
+import { db } from "../db";
+import { logAction } from "../utils/audit";
+
+interface CustomComponentsStore {
+  components: CustomComponent[];
+  load: () => Promise<void>;
+  add: (data: Omit<CustomComponent, "id">) => Promise<string>;
+  update: (component: CustomComponent) => Promise<void>;
+}
+
+export const useCustomComponents = create<CustomComponentsStore>()(
+  persist(
+    (set, get) => ({
+      components: [],
+      load: async () => {
+        const comps = await db.customComponents.toArray();
+        set({ components: comps });
+      },
+      add: async (data) => {
+        const id = nanoid();
+        const comp: CustomComponent = { id, ...data };
+        await db.customComponents.put(comp);
+        set({ components: [comp, ...get().components] });
+        await logAction("CUSTOM_COMPONENT_CREATED", "user", { componentId: id });
+        return id;
+      },
+      update: async (component) => {
+        await db.customComponents.put(component);
+        set({
+          components: get().components.map((c) =>
+            c.id === component.id ? component : c
+          ),
+        });
+        await logAction("CUSTOM_COMPONENT_UPDATED", "user", {
+          componentId: component.id,
+        });
+      },
+    }),
+    { name: "taco-custom-components" }
+  )
+);

--- a/src/pages/FlowEditor/StepForm/Custom.tsx
+++ b/src/pages/FlowEditor/StepForm/Custom.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { Input } from "../../../components/ui/input";
+import { Label } from "../../../components/ui/label";
+import { Textarea } from "../../../components/ui/textarea";
+import { Button } from "../../../components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../../components/ui/select";
+import type { Step } from "../../../types/flow";
+import type { CustomComponent } from "../../../types/flow";
+import { useCustomComponents } from "../../../hooks/useCustomComponents";
+
+interface Props {
+  step: Step;
+  setField: <K extends keyof Step>(key: K, value: Step[K]) => void;
+}
+
+const NEW_VALUE = "__NEW__";
+
+export default function CustomStepForm({ step, setField }: Props) {
+  const { components, load, add, update } = useCustomComponents();
+  const [current, setCurrent] = useState<CustomComponent | null>(null);
+  const [isNew, setIsNew] = useState(false);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const comp = components.find((c) => c.id === step.componentId) || null;
+    setCurrent(comp);
+    setIsNew(!comp && step.componentId === "");
+  }, [components, step.componentId]);
+
+  const handleSelect = (value: string) => {
+    if (value === NEW_VALUE) {
+      setCurrent({ id: "", name: "Novo componente", html: "", css: "", js: "" });
+      setIsNew(true);
+      setField("componentId", "");
+    } else {
+      const comp = components.find((c) => c.id === value) || null;
+      setCurrent(comp);
+      setIsNew(false);
+      setField("componentId", value);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!current) return;
+    if (isNew) {
+      const id = await add({
+        name: current.name || `Componente ${components.length + 1}`,
+        html: current.html,
+        css: current.css,
+        js: current.js,
+      });
+      setField("componentId", id);
+      setIsNew(false);
+      setCurrent({ ...current, id });
+    } else {
+      await update(current);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Componente</Label>
+        <Select
+          value={step.componentId || (isNew ? NEW_VALUE : "")}
+          onValueChange={handleSelect}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Escolha ou crie" />
+          </SelectTrigger>
+          <SelectContent>
+            {components.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+            <SelectItem value={NEW_VALUE}>Novo componente...</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {current && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="cc-name">Nome</Label>
+            <Input
+              id="cc-name"
+              value={current.name}
+              onChange={(e) =>
+                setCurrent({ ...current, name: e.target.value })
+              }
+              placeholder="Nome do componente"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cc-html">HTML</Label>
+            <Textarea
+              id="cc-html"
+              rows={3}
+              value={current.html}
+              onChange={(e) =>
+                setCurrent({ ...current, html: e.target.value })
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cc-css">CSS</Label>
+            <Textarea
+              id="cc-css"
+              rows={3}
+              value={current.css}
+              onChange={(e) => setCurrent({ ...current, css: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cc-js">JS</Label>
+            <Textarea
+              id="cc-js"
+              rows={3}
+              value={current.js}
+              onChange={(e) => setCurrent({ ...current, js: e.target.value })}
+            />
+          </div>
+          <Button size="sm" onClick={handleSave}>
+            {isNew ? "Criar" : "Atualizar"} componente
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -31,6 +31,9 @@ import { cn } from "../../../utils/cn";
 import TextStepForm from "./Text";
 import QuestionStepForm from "./Question";
 import MediaStepForm from "./Media";
+import CustomStepForm from "./Custom";
+import CustomRenderer from "../../../components/CustomRenderer";
+import { useCustomComponents } from "../../../hooks/useCustomComponents";
 
 interface Props {
   step: Step;
@@ -63,6 +66,14 @@ const STEP_TYPES = [
     icon: ImageIcon,
     color: "bg-purple-50 text-purple-700 border-purple-200",
     disabled: true,
+  },
+  {
+    value: "CUSTOM",
+    label: "Personalizado",
+    description: "HTML/CSS/JS",
+    icon: Save,
+    color: "bg-orange-50 text-orange-700 border-orange-200",
+    disabled: false,
   },
 ] as const;
 
@@ -220,6 +231,9 @@ export default function StepForm({ step, steps, onChange, onDelete }: Props) {
           <QuestionStepForm step={step} steps={steps} setField={setField} />
         )}
         {step.type === "MEDIA" && <MediaStepForm />}
+        {step.type === "CUSTOM" && (
+          <CustomStepForm step={step} setField={setField} />
+        )}
       </div>
     </div>
   );
@@ -231,6 +245,10 @@ interface StepPreviewProps {
 }
 
 function StepPreview({ step, onExitPreview }: StepPreviewProps) {
+  const { components } = useCustomComponents();
+  const custom = step.componentId
+    ? components.find((c) => c.id === step.componentId)
+    : null;
   return (
     <div className="h-full flex flex-col max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-8">
@@ -243,11 +261,15 @@ function StepPreview({ step, onExitPreview }: StepPreviewProps) {
         <CardContent className="p-8 lg:p-12">
           <div className="max-w-2xl mx-auto">
             <h1 className="text-3xl font-bold mb-8 text-center">{step.title}</h1>
-            <div className="prose prose-gray max-w-none mb-8">
-              <p className="text-lg leading-relaxed whitespace-pre-wrap text-center">
-                {step.content}
-              </p>
-            </div>
+            {step.type === "CUSTOM" && custom ? (
+              <CustomRenderer html={custom.html} css={custom.css} js={custom.js} />
+            ) : (
+              <div className="prose prose-gray max-w-none mb-8">
+                <p className="text-lg leading-relaxed whitespace-pre-wrap text-center">
+                  {step.content}
+                </p>
+              </div>
+            )}
             {step.type === "QUESTION" && step.options && step.options.length > 0 && (
               <div className="space-y-4">
                 <h3 className="text-lg font-medium text-center mb-6">

--- a/src/pages/FlowEditor/index.tsx
+++ b/src/pages/FlowEditor/index.tsx
@@ -38,8 +38,9 @@ import type { Flow, Step } from "../types/flow";
 
 const STEP_TYPES = {
   TEXT: { label: "Texto", color: "bg-blue-100 text-blue-800" },
-  FORM: { label: "Formulário", color: "bg-green-100 text-green-800" },
+  QUESTION: { label: "Pergunta", color: "bg-green-100 text-green-800" },
   MEDIA: { label: "Mídia", color: "bg-purple-100 text-purple-800" },
+  CUSTOM: { label: "Personalizado", color: "bg-orange-100 text-orange-800" },
 } as const;
 
 export default function FlowEditor() {

--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -4,6 +4,8 @@ import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { Badge } from "../../components/ui/badge";
 import { cn } from "../../utils/cn";
+import CustomRenderer from "../../components/CustomRenderer";
+import { useCustomComponents } from "../../hooks/useCustomComponents";
 
 interface Props {
   step: Step;
@@ -24,6 +26,10 @@ export default function StepCard({
   goBack,
   canGoBack,
 }: Props) {
+  const { components } = useCustomComponents();
+  const custom = step.componentId
+    ? components.find((c) => c.id === step.componentId)
+    : null;
   return (
     <Card className="shadow-xl border-0 bg-white/95 backdrop-blur-sm">
       <CardContent className="p-8 sm:p-12">
@@ -42,11 +48,15 @@ export default function StepCard({
 
           {/* Step Content */}
           <div className="text-center">
-            <div className="prose prose-lg max-w-none text-muted-foreground">
-              <p className="whitespace-pre-wrap leading-relaxed">
-                {step.content}
-              </p>
-            </div>
+            {step.type === "CUSTOM" && custom ? (
+              <CustomRenderer html={custom.html} css={custom.css} js={custom.js} />
+            ) : (
+              <div className="prose prose-lg max-w-none text-muted-foreground">
+                <p className="whitespace-pre-wrap leading-relaxed">
+                  {step.content}
+                </p>
+              </div>
+            )}
           </div>
 
           {/* Step Actions */}

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -10,16 +10,29 @@ export interface StepOption {
 }
 
 /**
+ * Componente customizado salvo pelo usuário para reutilização.
+ */
+export interface CustomComponent {
+  id: string;
+  name: string;
+  html: string;
+  css: string;
+  js: string;
+}
+
+/**
  * Representa um passo dentro de um Flow.
  * Inclui título, conteúdo e, opcionalmente, opções de ramificação.
  */
 export interface Step {
   id: string;
   order: number;
-  type: "TEXT" | "QUESTION" | "MEDIA";
+  type: "TEXT" | "QUESTION" | "MEDIA" | "CUSTOM";
   title: string;
   content: string;
   options?: StepOption[];
+  /** Referência para o componente customizado a ser renderizado */
+  componentId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend Step and database types for custom HTML components
- store custom components in IndexedDB via new hook
- render user components in sandboxed iframe using DOMPurify
- add editor UI for creating or selecting saved components
- support custom step type during playback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: module resolution errors due to offline env)*

------
https://chatgpt.com/codex/tasks/task_e_686a0db2facc8322b48526de2bf2375b