### PR TITLE
Add markdown renderer to flow pages

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,12 @@
+import type React from "react";
+import { parseMarkdown } from "../utils/markdown";
+
+interface Props {
+  content: string;
+  className?: string;
+}
+
+export default function Markdown({ content, className }: Props) {
+  const html = parseMarkdown(content);
+  return <div className={className} dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -33,6 +33,7 @@ import QuestionStepForm from "./Question";
 import MediaStepForm from "./Media";
 import CustomStepForm from "./Custom";
 import CustomRenderer from "../../../components/CustomRenderer";
+import Markdown from "../../../components/Markdown";
 import { useCustomComponents } from "../../../hooks/useCustomComponents";
 
 interface Props {
@@ -264,11 +265,10 @@ function StepPreview({ step, onExitPreview }: StepPreviewProps) {
             {step.type === "CUSTOM" && custom ? (
               <CustomRenderer html={custom.html} css={custom.css} js={custom.js} />
             ) : (
-              <div className="prose prose-gray max-w-none mb-8">
-                <p className="text-lg leading-relaxed whitespace-pre-wrap text-center">
-                  {step.content}
-                </p>
-              </div>
+              <Markdown
+                content={step.content}
+                className="prose prose-gray max-w-none mb-8 text-center"
+              />
             )}
             {step.type === "QUESTION" && step.options && step.options.length > 0 && (
               <div className="space-y-4">

--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "../../components/ui/card";
 import { Badge } from "../../components/ui/badge";
 import { cn } from "../../utils/cn";
 import CustomRenderer from "../../components/CustomRenderer";
+import Markdown from "../../components/Markdown";
 import { useCustomComponents } from "../../hooks/useCustomComponents";
 
 interface Props {
@@ -51,11 +52,10 @@ export default function StepCard({
             {step.type === "CUSTOM" && custom ? (
               <CustomRenderer html={custom.html} css={custom.css} js={custom.js} />
             ) : (
-              <div className="prose prose-lg max-w-none text-muted-foreground">
-                <p className="whitespace-pre-wrap leading-relaxed">
-                  {step.content}
-                </p>
-              </div>
+              <Markdown
+                content={step.content}
+                className="prose prose-lg max-w-none text-muted-foreground"
+              />
             )}
           </div>
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,46 @@
+export function parseMarkdown(text: string): string {
+  let escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  const processInline = (str: string) =>
+    str
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/`(.+?)`/g, '<code>$1</code>')
+      .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+
+  const lines = escaped.split(/\n/);
+  const htmlLines: string[] = [];
+  let inList = false;
+  for (const line of lines) {
+    const listMatch = /^\s*[-*] (.+)/.exec(line);
+    if (listMatch) {
+      if (!inList) {
+        htmlLines.push('<ul>');
+        inList = true;
+      }
+      htmlLines.push('<li>' + processInline(listMatch[1]) + '</li>');
+      continue;
+    }
+    if (inList) {
+      htmlLines.push('</ul>');
+      inList = false;
+    }
+    let m;
+    if ((m = /^### (.+)/.exec(line))) {
+      htmlLines.push('<h3>' + processInline(m[1]) + '</h3>');
+    } else if ((m = /^## (.+)/.exec(line))) {
+      htmlLines.push('<h2>' + processInline(m[1]) + '</h2>');
+    } else if ((m = /^# (.+)/.exec(line))) {
+      htmlLines.push('<h1>' + processInline(m[1]) + '</h1>');
+    } else if (line.trim() === '') {
+      htmlLines.push('');
+    } else {
+      htmlLines.push('<p>' + processInline(line) + '</p>');
+    }
+  }
+  if (inList) htmlLines.push('</ul>');
+  return htmlLines.join('\n');
+}


### PR DESCRIPTION
## Summary
- implement simple Markdown parser
- add Markdown component
- render Markdown in FlowPlayer and FlowEditor preview

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a10cd06148322b793bee85611e92c