### PR TITLE
Support markdown in flow step option labels

### DIFF
--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -34,6 +34,7 @@ import MediaStepForm from "./Media";
 import CustomStepForm from "./Custom";
 import CustomRenderer from "../../../components/CustomRenderer";
 import Markdown from "../../../components/Markdown";
+import { parseInlineMarkdown } from "../../../utils/markdown";
 import { useCustomComponents } from "../../../hooks/useCustomComponents";
 
 interface Props {
@@ -287,7 +288,12 @@ function StepPreview({ step, onExitPreview }: StepPreviewProps) {
                       <span className="mr-3 text-muted-foreground font-medium">
                         {index + 1}.
                       </span>
-                      <span className="text-base">{option.label}</span>
+                      <span
+                        className="text-base"
+                        dangerouslySetInnerHTML={{
+                          __html: parseInlineMarkdown(option.label),
+                        }}
+                      />
                     </Button>
                   ))}
                 </div>

--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../../components/ui/badge";
 import { cn } from "../../utils/cn";
 import CustomRenderer from "../../components/CustomRenderer";
 import Markdown from "../../components/Markdown";
+import { parseInlineMarkdown } from "../../utils/markdown";
 import { useCustomComponents } from "../../hooks/useCustomComponents";
 
 interface Props {
@@ -78,7 +79,12 @@ export default function StepCard({
                       <span className="mr-3 text-muted-foreground font-medium">
                         {optIndex + 1}.
                       </span>
-                      <span className="text-base">{opt.label}</span>
+                      <span
+                        className="text-base"
+                        dangerouslySetInnerHTML={{
+                          __html: parseInlineMarkdown(opt.label),
+                        }}
+                      />
                     </Button>
                   ))}
                 </div>

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,15 +1,24 @@
-export function parseMarkdown(text: string): string {
-  let escaped = text
+function processInline(str: string) {
+  return str
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`(.+?)`/g, '<code>$1</code>')
+    .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+}
+
+export function parseInlineMarkdown(text: string): string {
+  const escaped = text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+  return processInline(escaped);
+}
 
-  const processInline = (str: string) =>
-    str
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.+?)\*/g, '<em>$1</em>')
-      .replace(/`(.+?)`/g, '<code>$1</code>')
-      .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+export function parseMarkdown(text: string): string {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 
   const lines = escaped.split(/\n/);
   const htmlLines: string[] = [];


### PR DESCRIPTION
## Summary
- allow rendering markdown inline for question step options in FlowPlayer and editor preview
- expose `parseInlineMarkdown` util to parse inline fragments

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a1678341c8322a87dffde359b159e