### PR TITLE
Add settings page and icon-only menu

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import Dashboard from "./pages/Dashboard";
 import FlowPlayer from "./pages/FlowPlayer";
 import Analytics from "./pages/Analytics";
 import FlowEditor from "./pages/FlowEditor";
+import Settings from "./pages/Settings";
 
 registerSW({ immediate: true });
 
@@ -29,6 +30,9 @@ createRoot(document.getElementById("root")!).render(
 
         {/* Analytics de um fluxo */}
         <Route path="/flows/:id/analytics" element={<Analytics />} />
+
+        {/* Configurações do usuário */}
+        <Route path="/settings" element={<Settings />} />
 
         {/* Qualquer rota desconhecida redireciona para o Dashboard */}
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import {
   Plus,
   Copy,
@@ -15,6 +15,7 @@ import {
   Download,
   Upload,
   Trash2,
+  Settings,
 } from "lucide-react";
 import { useFlows } from "../hooks/useFlows";
 import { useToast } from "../hooks/use-toast";
@@ -175,6 +176,11 @@ export default function Dashboard() {
               </p>
             </div>
             <div className="flex gap-2">
+              <Button variant="ghost" size="icon" asChild>
+                <Link to="/settings">
+                  <Settings className="h-5 w-5" />
+                </Link>
+              </Button>
               <Button onClick={handleNew} disabled={isCreating} size="lg">
                 <Plus className="mr-2 h-4 w-4" />
                 {isCreating ? "Criando..." : "Novo Fluxo"}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,107 @@
+import { Link } from "react-router-dom";
+import { Home, Settings as SettingsIcon, User } from "lucide-react";
+
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
+
+interface NavItemProps {
+  to: string;
+  icon: JSX.Element;
+  label: string;
+  active?: boolean;
+}
+
+function NavItem({ to, icon, label, active }: NavItemProps) {
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-2 p-2 rounded-md ${
+        active
+          ? "bg-secondary text-secondary-foreground font-medium"
+          : "text-muted-foreground hover:bg-muted"
+      }`}
+    >
+      {icon}
+      <span>{label}</span>
+    </Link>
+  );
+}
+
+export default function Settings() {
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-56 border-r p-4 space-y-2">
+        <NavItem to="/" icon={<Home className="h-4 w-4" />} label="Dashboard" />
+        <NavItem
+          to="/settings"
+          icon={<SettingsIcon className="h-4 w-4" />}
+          label="Perfil"
+          active
+        />
+      </aside>
+
+      <main className="flex-1 p-6 space-y-6">
+        <h1 className="text-2xl font-bold">Seu perfil</h1>
+
+        <section className="flex items-center gap-4">
+          <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center">
+            <User className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div className="space-x-2">
+            <Button variant="outline" size="sm">
+              Alterar foto
+            </Button>
+            <Button variant="ghost" size="sm">
+              Remover foto
+            </Button>
+          </div>
+        </section>
+
+        <section className="bg-background rounded-md shadow p-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Nome</label>
+            <Input placeholder="Seu nome" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Email</label>
+            <Input type="email" placeholder="Seu email" />
+          </div>
+        </section>
+
+        <section className="bg-background rounded-md shadow p-4 space-y-2">
+          <label className="block text-sm font-medium mb-1">Uso do sistema</label>
+          <Select>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="Escolha" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="pessoal">Pessoal</SelectItem>
+              <SelectItem value="empresa">Empresa</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            Defina como pretende usar o sistema
+          </p>
+        </section>
+
+        <section className="pt-4 border-t">
+          <h2 className="font-semibold mb-3">Contas conectadas</h2>
+          <div className="flex items-center justify-between rounded-md border p-3">
+            <span>Google</span>
+            <Button size="sm" variant="outline">
+              Desconectar
+            </Button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new settings page with sidebar and profile form
- add settings route to main application router
- place a settings icon button in the dashboard header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a203ca3f4832281f10d4225d560a5