### PR TITLE
Add navigation for hidden pages

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,9 @@ import FlowPlayer from "./pages/FlowPlayer";
 import Analytics from "./pages/Analytics";
 import FlowEditor from "./pages/FlowEditor";
 import Settings from "./pages/Settings";
+import AuditTrail from "./pages/AuditTrail";
+import FlowImportExport from "./pages/FlowImportExport";
+import PathAnalytics from "./pages/PathAnalytics";
 
 registerSW({ immediate: true });
 
@@ -33,6 +36,15 @@ createRoot(document.getElementById("root")!).render(
 
         {/* Configurações do usuário */}
         <Route path="/settings" element={<Settings />} />
+
+        {/* Log de auditoria */}
+        <Route path="/audit" element={<AuditTrail />} />
+
+        {/* Importação e exportação de fluxos */}
+        <Route path="/import-export" element={<FlowImportExport />} />
+
+        {/* Path Analytics */}
+        <Route path="/path-analytics" element={<PathAnalytics />} />
 
         {/* Qualquer rota desconhecida redireciona para o Dashboard */}
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/pages/PathAnalytics.tsx
+++ b/src/pages/PathAnalytics.tsx
@@ -1,0 +1,13 @@
+import { BarChart3 } from "lucide-react";
+
+export default function PathAnalytics() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold flex items-center gap-2">
+        <BarChart3 className="h-5 w-5" />
+        Path Analytics
+      </h1>
+      <p className="text-muted-foreground">Funcionalidade em desenvolvimento.</p>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,12 @@
 import { Link } from "react-router-dom";
-import { Home, Settings as SettingsIcon, User } from "lucide-react";
+import {
+  Home,
+  Settings as SettingsIcon,
+  User,
+  Activity,
+  FileText,
+  BarChart3,
+} from "lucide-react";
 
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
@@ -44,6 +51,21 @@ export default function Settings() {
           icon={<SettingsIcon className="h-4 w-4" />}
           label="Perfil"
           active
+        />
+        <NavItem
+          to="/audit"
+          icon={<Activity className="h-4 w-4" />}
+          label="Auditoria"
+        />
+        <NavItem
+          to="/import-export"
+          icon={<FileText className="h-4 w-4" />}
+          label="Import/Export"
+        />
+        <NavItem
+          to="/path-analytics"
+          icon={<BarChart3 className="h-4 w-4" />}
+          label="Path Analytics"
         />
       </aside>
 


### PR DESCRIPTION
## Summary
- expose AuditTrail, FlowImportExport and PathAnalytics pages in the main router
- update the settings sidebar with links to these pages
- implement a placeholder for PathAnalytics

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a25bc69d08322a6605c621c2257eb