### PR TITLE
Fix FlowPlayer variable initialization

### DIFF
--- a/src/pages/FlowPlayer/index.tsx
+++ b/src/pages/FlowPlayer/index.tsx
@@ -22,6 +22,20 @@ export default function FlowPlayer() {
   const [isExiting, setIsExiting] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
 
+  const flow = flows.find((f) => f.id === id);
+  const {
+    step,
+    index,
+    progress,
+    next,
+    choose,
+    canGoBack,
+    goBack,
+    pause,
+    resume,
+    isPaused,
+  } = usePlayer(flow);
+
   useEffect(() => {
     load();
   }, [load]);
@@ -41,21 +55,6 @@ export default function FlowPlayer() {
     tick();
     return () => clearInterval(interval);
   }, [startTime, pausedTotal, index]);
-
-
-  const flow = flows.find((f) => f.id === id);
-  const {
-    step,
-    index,
-    progress,
-    next,
-    choose,
-    canGoBack,
-    goBack,
-    pause,
-    resume,
-    isPaused,
-  } = usePlayer(flow);
 
   const handleExit = () => {
     setIsExiting(true);


### PR DESCRIPTION
## Summary
- ensure `usePlayer` hook is invoked before `useEffect` that references its variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules such as `vite` and `react/jsx-runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_686a2885fd34832286eef22bb58852e5