### PR TITLE
Fix progress session filtering

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -72,7 +72,7 @@ export default function Dashboard() {
     async function fetchProgress() {
       const sessions = await db.sessions
         .where("isPaused")
-        .equals(1)
+        .equals(true)
         .and((s) => !s.finishedAt)
         .toArray();
       setProgressSessions(sessions);


### PR DESCRIPTION
## Summary
- ensure paused sessions are correctly fetched by the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a878964248322ad2f9acb83dca1d1