### PR TITLE
Add next step selection

### DIFF
--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -246,8 +246,16 @@ export function usePlayer(flow?: Flow, loadSessionId?: string): PlayerState {
   // Funções expostas
   const next = useCallback(() => {
     if (!flow) return;
-    const newIdx = index + 1 < flow.steps.length ? index + 1 : -1;
-    goToIndex(newIdx);
+    const current = flow.steps[index];
+    if (!current) return;
+    if (current.nextStepId !== undefined) {
+      const targetIdx = flow.steps.findIndex((s) => s.id === current.nextStepId);
+      const newIdx = targetIdx >= 0 ? targetIdx : -1;
+      goToIndex(newIdx);
+    } else {
+      const newIdx = index + 1 < flow.steps.length ? index + 1 : -1;
+      goToIndex(newIdx);
+    }
   }, [flow, index, goToIndex]);
 
   const choose = useCallback(

--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -235,11 +235,46 @@ export default function StepForm({ step, steps, onChange, onDelete }: Props) {
                   "border-destructive focus-visible:ring-destructive"
               )}
             />
-            <p className="text-xs text-muted-foreground">
-              {step.content.length} caracteres • Suporte a Markdown
-            </p>
-          </div>
+          <p className="text-xs text-muted-foreground">
+            {step.content.length} caracteres • Suporte a Markdown
+          </p>
         </div>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Próximo passo</Label>
+          <Select
+            value={
+              step.nextStepId === undefined
+                ? "__DEFAULT__"
+                : step.nextStepId === ""
+                ? "__END__"
+                : step.nextStepId
+            }
+            onValueChange={(val) => {
+              if (val === "__DEFAULT__") {
+                setField("nextStepId", undefined as unknown as Step["nextStepId"]);
+              } else if (val === "__END__") {
+                setField("nextStepId", "" as Step["nextStepId"]);
+              } else {
+                setField("nextStepId", val as Step["nextStepId"]);
+              }
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Sequencial" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__DEFAULT__">Sequencial</SelectItem>
+              <SelectItem value="__END__">Finalizar</SelectItem>
+              {steps.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {s.order + 1}. {s.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
 
         {step.type === "TEXT" && <TextStepForm step={step} />}
         {step.type === "QUESTION" && (

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -30,6 +30,8 @@ export interface Step {
   type: "TEXT" | "QUESTION" | "MEDIA" | "CUSTOM" | "WEBHOOK";
   title: string;
   content: string;
+  /** ID do passo para o qual este passo deve redirecionar. Se vazio, finaliza o fluxo. */
+  nextStepId?: string;
   options?: StepOption[];
   /** Referência para o componente customizado a ser renderizado */
   componentId?: string;

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -9,6 +9,9 @@ export function buildNetworkGraph(steps: Step[]): GraphEdge[] {
           edges.push({ source: step.id, target: o.targetStepId });
         }
       });
+    } else if (step.nextStepId !== undefined) {
+      const target = steps.find((s) => s.id === step.nextStepId);
+      if (target) edges.push({ source: step.id, target: target.id });
     } else {
       const next = steps[idx + 1];
       if (next) edges.push({ source: step.id, target: next.id });


### PR DESCRIPTION
## Summary
- allow specifying next step when editing steps
- add `nextStepId` to Step type
- support `nextStepId` in player and graphs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a89520c8883229360c6e9aa69f89a