### PR TITLE
Add configurable run count in analytics

### DIFF
--- a/src/hooks/useAnalyticsConfig.ts
+++ b/src/hooks/useAnalyticsConfig.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AnalyticsConfigStore {
+  runsToShow: number | "all";
+  customOptions: number[];
+  setRunsToShow: (v: number | "all") => void;
+  addCustomOption: (v: number) => void;
+}
+
+export const useAnalyticsConfig = create<AnalyticsConfigStore>()(
+  persist(
+    (set, get) => ({
+      runsToShow: 5,
+      customOptions: [],
+      setRunsToShow: (v) => set({ runsToShow: v }),
+      addCustomOption: (v) =>
+        set((state) => {
+          if (state.customOptions.includes(v)) return {};
+          const arr = [...state.customOptions, v].sort((a, b) => a - b);
+          return { customOptions: arr };
+        }),
+    }),
+    { name: "taco-analytics-config" }
+  )
+);


### PR DESCRIPTION
## Summary
- make number of runs shown in analytics configurable
- persist analytics options in local storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686a8b0716fc83229e467f89a37b0d23