### PR TITLE
Add page for managing custom components

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import Settings from "./pages/Settings";
 import AuditTrail from "./pages/AuditTrail";
 import FlowImportExport from "./pages/FlowImportExport";
 import PathAnalytics from "./pages/PathAnalytics";
+import CustomComponents from "./pages/CustomComponents";
 
 registerSW({ immediate: true });
 
@@ -45,6 +46,9 @@ createRoot(document.getElementById("root")!).render(
 
         {/* Path Analytics */}
         <Route path="/path-analytics" element={<PathAnalytics />} />
+
+        {/* Componentes personalizados */}
+        <Route path="/components" element={<CustomComponents />} />
 
         {/* Qualquer rota desconhecida redireciona para o Dashboard */}
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/pages/CustomComponents.tsx
+++ b/src/pages/CustomComponents.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Home,
+  Settings as SettingsIcon,
+  User,
+  Activity,
+  FileText,
+  BarChart3,
+} from "lucide-react";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Textarea } from "../components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
+import { Label } from "../components/ui/label";
+import type { CustomComponent } from "../types/flow";
+import { useCustomComponents } from "../hooks/useCustomComponents";
+
+interface NavItemProps {
+  to: string;
+  icon: JSX.Element;
+  label: string;
+  active?: boolean;
+}
+
+function NavItem({ to, icon, label, active }: NavItemProps) {
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-2 p-2 rounded-md ${
+        active
+          ? "bg-secondary text-secondary-foreground font-medium"
+          : "text-muted-foreground hover:bg-muted"
+      }`}
+    >
+      {icon}
+      <span>{label}</span>
+    </Link>
+  );
+}
+
+function sanitizeHtml(html: string) {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  for (const script of template.content.querySelectorAll("script")) {
+    script.remove();
+  }
+  for (const element of template.content.querySelectorAll("*")) {
+    for (const attr of Array.from(element.attributes)) {
+      if (attr.name.startsWith("on")) {
+        element.removeAttribute(attr.name);
+      }
+    }
+  }
+  return template.innerHTML;
+}
+
+function sanitizeCss(css: string) {
+  return css.replace(/<[^>]*>?/gm, "");
+}
+
+const NEW_VALUE = "__NEW__";
+
+export default function CustomComponents() {
+  const { components, load, add, update } = useCustomComponents();
+  const [current, setCurrent] = useState<CustomComponent | null>(null);
+  const [isNew, setIsNew] = useState(false);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const DEFAULT_COMPONENT: CustomComponent = {
+    id: "",
+    name: "Novo componente",
+    html: "",
+    css: "",
+    js: "",
+  };
+
+  const handleSelect = (value: string) => {
+    if (value === NEW_VALUE || value === "") {
+      setCurrent(DEFAULT_COMPONENT);
+      setIsNew(true);
+    } else {
+      const comp = components.find((c) => c.id === value) || DEFAULT_COMPONENT;
+      setCurrent(comp);
+      setIsNew(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!current) return;
+
+    const sanitized = {
+      ...current,
+      html: sanitizeHtml(current.html),
+      css: sanitizeCss(current.css),
+    };
+
+    if (isNew) {
+      const id = await add({
+        name: sanitized.name || `Componente ${components.length + 1}`,
+        html: sanitized.html,
+        css: sanitized.css,
+        js: sanitized.js,
+      });
+      setIsNew(false);
+      setCurrent({ ...sanitized, id });
+    } else {
+      await update(sanitized);
+      setCurrent(sanitized);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-56 border-r p-4 space-y-2">
+        <NavItem to="/" icon={<Home className="h-4 w-4" />} label="Dashboard" />
+        <NavItem
+          to="/settings"
+          icon={<SettingsIcon className="h-4 w-4" />}
+          label="Perfil"
+        />
+        <NavItem to="/audit" icon={<Activity className="h-4 w-4" />} label="Auditoria" />
+        <NavItem to="/import-export" icon={<FileText className="h-4 w-4" />} label="Import/Export" />
+        <NavItem to="/path-analytics" icon={<BarChart3 className="h-4 w-4" />} label="Path Analytics" />
+        <NavItem
+          to="/components"
+          icon={<User className="h-4 w-4" />}
+          label="Componentes"
+          active
+        />
+      </aside>
+
+      <main className="flex-1 p-6 space-y-6">
+        <h1 className="text-2xl font-bold">Componentes</h1>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Componente</Label>
+            <Select value={current?.id || (isNew ? NEW_VALUE : "")} onValueChange={handleSelect}>
+              <SelectTrigger>
+                <SelectValue placeholder="Escolha ou crie" />
+              </SelectTrigger>
+              <SelectContent>
+                {components.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                  </SelectItem>
+                ))}
+                <SelectItem value={NEW_VALUE}>Novo componente...</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {current && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="cc-name">Nome</Label>
+                <Input
+                  id="cc-name"
+                  value={current.name}
+                  onChange={(e) => setCurrent({ ...current, name: e.target.value })}
+                  placeholder="Nome do componente"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cc-html">HTML</Label>
+                <Textarea
+                  id="cc-html"
+                  rows={3}
+                  value={current.html}
+                  onChange={(e) => setCurrent({ ...current, html: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cc-css">CSS</Label>
+                <Textarea
+                  id="cc-css"
+                  rows={3}
+                  value={current.css}
+                  onChange={(e) => setCurrent({ ...current, css: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cc-js">JS</Label>
+                <Textarea
+                  id="cc-js"
+                  rows={3}
+                  value={current.js}
+                  onChange={(e) => setCurrent({ ...current, js: e.target.value })}
+                />
+              </div>
+              <Button size="sm" onClick={handleSave}>
+                {isNew ? "Criar" : "Atualizar"} componente
+              </Button>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -122,6 +122,13 @@ export default function Settings() {
             </Button>
           </div>
         </section>
+
+        <section className="pt-4 border-t">
+          <h2 className="font-semibold mb-3">Componentes personalizados</h2>
+          <Button asChild size="sm" variant="outline">
+            <Link to="/components">Gerenciar componentes</Link>
+          </Button>
+        </section>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new `CustomComponents` page with form to create or edit custom components
- expose new route `/components`
- link to custom components screen from the settings page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a9a317c18832285a6400cbb075dce