### PR TITLE
Hide sequential option for question step

### DIFF
--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -121,6 +121,12 @@ export default function StepForm({ step, steps, onChange, onDelete }: Props) {
     setValidationErrors(validateStep(updated));
   }, [step, onChange, validateStep]);
 
+  useEffect(() => {
+    if (step.type === "QUESTION" && step.nextStepId !== undefined) {
+      setField("nextStepId", undefined as unknown as Step["nextStepId"]);
+    }
+  }, [step.type]);
+
   const currentStepType = STEP_TYPES.find((t) => t.value === step.type);
 
   if (isPreviewMode) {
@@ -240,40 +246,42 @@ export default function StepForm({ step, steps, onChange, onDelete }: Props) {
           </p>
         </div>
 
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">Próximo passo</Label>
-          <Select
-            value={
-              step.nextStepId === undefined
-                ? "__DEFAULT__"
-                : step.nextStepId === ""
-                ? "__END__"
-                : step.nextStepId
-            }
-            onValueChange={(val) => {
-              if (val === "__DEFAULT__") {
-                setField("nextStepId", undefined as unknown as Step["nextStepId"]);
-              } else if (val === "__END__") {
-                setField("nextStepId", "" as Step["nextStepId"]);
-              } else {
-                setField("nextStepId", val as Step["nextStepId"]);
+        {step.type !== "QUESTION" && (
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Próximo passo</Label>
+            <Select
+              value={
+                step.nextStepId === undefined
+                  ? "__DEFAULT__"
+                  : step.nextStepId === ""
+                  ? "__END__"
+                  : step.nextStepId
               }
-            }}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Sequencial" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__DEFAULT__">Sequencial</SelectItem>
-              <SelectItem value="__END__">Finalizar</SelectItem>
-              {steps.map((s) => (
-                <SelectItem key={s.id} value={s.id}>
-                  {s.order + 1}. {s.title}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+              onValueChange={(val) => {
+                if (val === "__DEFAULT__") {
+                  setField("nextStepId", undefined as unknown as Step["nextStepId"]);
+                } else if (val === "__END__") {
+                  setField("nextStepId", "" as Step["nextStepId"]);
+                } else {
+                  setField("nextStepId", val as Step["nextStepId"]);
+                }
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Sequencial" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__DEFAULT__">Sequencial</SelectItem>
+                <SelectItem value="__END__">Finalizar</SelectItem>
+                {steps.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    {s.order + 1}. {s.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
       </div>
 
         {step.type === "TEXT" && <TextStepForm step={step} />}


### PR DESCRIPTION
## Summary
- hide next step selector when the step type is a question
- reset `nextStepId` to sequential when switching to question type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a9b5212d88322ae79a07e0cee379e