### PR TITLE
Fix next button text

### DIFF
--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -137,7 +137,12 @@ export default function StepCard({
               ) : (
                 <div className="flex justify-center">
                   <Button size="lg" onClick={next} className="px-8">
-                    {current === total ? "Finalizar" : "Continuar"}
+                    {(
+                      step.nextStepId === "" ||
+                      (step.nextStepId === undefined && current === total)
+                    )
+                      ? "Finalizar"
+                      : "Próximo"}
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
                 </div>


### PR DESCRIPTION
## Summary
- adjust the Next button label to show "Finalizar" whenever advancing will finish the flow
- default label changed from "Continuar" to "Próximo"

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a9e7922f883228c6f57a1bc3ae598