### PR TITLE
Enable media step

### DIFF
--- a/src/pages/FlowEditor/StepForm/Media.tsx
+++ b/src/pages/FlowEditor/StepForm/Media.tsx
@@ -1,5 +1,46 @@
-export default function MediaStepForm() {
+import { Input } from "../../../components/ui/input";
+import { Label } from "../../../components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../components/ui/select";
+import type { Step } from "../../../types/flow";
+
+interface Props {
+  step: Step;
+  setField: <K extends keyof Step>(key: K, value: Step[K]) => void;
+}
+
+export default function MediaStepForm({ step, setField }: Props) {
   return (
-    <p className="text-sm text-muted-foreground">Formulário de mídia ainda não implementado.</p>
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="media-url">URL da Mídia</Label>
+        <Input
+          id="media-url"
+          value={step.mediaUrl || ""}
+          onChange={(e) => setField("mediaUrl", e.target.value)}
+          placeholder="https://exemplo.com/arquivo.png"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="media-type">Tipo</Label>
+        <Select
+          value={step.mediaType || "image"}
+          onValueChange={(val) => setField("mediaType", val as Step["mediaType"])}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="image">Imagem</SelectItem>
+            <SelectItem value="video">Vídeo</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {step.mediaUrl && step.mediaType === "image" && (
+        <img src={step.mediaUrl} alt="preview" className="max-h-60 mx-auto" />
+      )}
+      {step.mediaUrl && step.mediaType === "video" && (
+        <video src={step.mediaUrl} controls className="max-h-60 mx-auto" />
+      )}
+    </div>
   );
 }

--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -69,7 +69,7 @@ const STEP_TYPES = [
     description: "Imagens e vídeos",
     icon: ImageIcon,
     color: "bg-purple-50 text-purple-700 border-purple-200",
-    disabled: true,
+    disabled: false,
   },
   {
     value: "CUSTOM",
@@ -110,6 +110,9 @@ export default function StepForm({ step, steps, onChange, onDelete }: Props) {
     }
     if (current.type === "WEBHOOK" && !current.webhookUrl) {
       errors.push("URL do webhook é obrigatória");
+    }
+    if (current.type === "MEDIA" && !current.mediaUrl) {
+      errors.push("URL da mídia é obrigatória");
     }
     return errors;
   }, []);
@@ -288,7 +291,9 @@ export default function StepForm({ step, steps, onChange, onDelete }: Props) {
         {step.type === "QUESTION" && (
           <QuestionStepForm step={step} steps={steps} setField={setField} />
         )}
-        {step.type === "MEDIA" && <MediaStepForm />}
+        {step.type === "MEDIA" && (
+          <MediaStepForm step={step} setField={setField} />
+        )}
         {step.type === "CUSTOM" && (
           <CustomStepForm step={step} setField={setField} />
         )}
@@ -322,6 +327,21 @@ function StepPreview({ step, onExitPreview }: StepPreviewProps) {
         <CardContent className="p-8 lg:p-12">
           <div className="max-w-2xl mx-auto">
             <h1 className="text-3xl font-bold mb-8 text-center">{step.title}</h1>
+            {step.type === "MEDIA" && step.mediaUrl && (
+              step.mediaType === "video" ? (
+                <video
+                  src={step.mediaUrl}
+                  controls
+                  className="mx-auto mb-8 max-h-96"
+                />
+              ) : (
+                <img
+                  src={step.mediaUrl}
+                  alt=""
+                  className="mx-auto mb-8 max-h-96"
+                />
+              )
+            )}
             {step.type === "CUSTOM" && custom ? (
               <CustomRenderer html={custom.html} css={custom.css} js={custom.js} />
             ) : (

--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -96,6 +96,21 @@ export default function StepCard({
 
             {/* Step Content */}
             <div className="text-center">
+              {step.type === "MEDIA" && step.mediaUrl && (
+                step.mediaType === "video" ? (
+                  <video
+                    src={step.mediaUrl}
+                    controls
+                    className="mx-auto mb-6 max-h-96"
+                  />
+                ) : (
+                  <img
+                    src={step.mediaUrl}
+                    alt=""
+                    className="mx-auto mb-6 max-h-96"
+                  />
+                )
+              )}
               {step.type === "CUSTOM" && custom ? (
                 <CustomRenderer
                   html={custom.html}

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -30,6 +30,10 @@ export interface Step {
   type: "TEXT" | "QUESTION" | "MEDIA" | "CUSTOM" | "WEBHOOK";
   title: string;
   content: string;
+  /** URL de imagem ou vídeo para passos do tipo MEDIA */
+  mediaUrl?: string;
+  /** Tipo da mídia associada */
+  mediaType?: "image" | "video";
   /** ID do passo para o qual este passo deve redirecionar. Se vazio, finaliza o fluxo. */
   nextStepId?: string;
   options?: StepOption[];


### PR DESCRIPTION
## Summary
- allow Media step type in step editor
- add `mediaUrl` and `mediaType` fields to Step type
- implement Media step form with preview
- render media in editor preview and player

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686aa35f175c832283cd7b493f67a914