### PR TITLE
Persist dashboard view mode

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -46,6 +46,18 @@ export default function Dashboard() {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  // Load view mode preference from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem("taco-dashboard-view");
+    if (saved === "grid" || saved === "list") {
+      setViewMode(saved as ViewMode);
+    }
+  }, []);
+
+  // Persist view mode preference to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem("taco-dashboard-view", viewMode);
+  }, [viewMode]);
   const [isCreating, setIsCreating] = useState(false);
   const [isSelecting, setIsSelecting] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- keep user's dashboard view mode (grid/list) between reloads via localStorage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aa40777148322baf4aefb40263829