### PR TITLE
Enable component CRUD modal and settings tab

### DIFF
--- a/src/components/CustomComponentManager.tsx
+++ b/src/components/CustomComponentManager.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import { Label } from "./ui/label";
+import type { CustomComponent } from "../types/flow";
+import { useCustomComponents } from "../hooks/useCustomComponents";
+
+function sanitizeHtml(html: string) {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  for (const script of template.content.querySelectorAll("script")) {
+    script.remove();
+  }
+  for (const element of template.content.querySelectorAll("*")) {
+    for (const attr of Array.from(element.attributes)) {
+      if (attr.name.startsWith("on")) {
+        element.removeAttribute(attr.name);
+      }
+    }
+  }
+  return template.innerHTML;
+}
+
+function sanitizeCss(css: string) {
+  return css.replace(/<[^>]*>?/gm, "");
+}
+
+const NEW_VALUE = "__NEW__";
+
+export default function CustomComponentManager() {
+  const { components, load, add, update } = useCustomComponents();
+  const [current, setCurrent] = useState<CustomComponent | null>(null);
+  const [isNew, setIsNew] = useState(false);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const DEFAULT_COMPONENT: CustomComponent = {
+    id: "",
+    name: "Novo componente",
+    html: "",
+    css: "",
+    js: "",
+  };
+
+  const handleSelect = (value: string) => {
+    if (value === NEW_VALUE || value === "") {
+      setCurrent(DEFAULT_COMPONENT);
+      setIsNew(true);
+    } else {
+      const comp = components.find((c) => c.id === value) || DEFAULT_COMPONENT;
+      setCurrent(comp);
+      setIsNew(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!current) return;
+
+    const sanitized = {
+      ...current,
+      html: sanitizeHtml(current.html),
+      css: sanitizeCss(current.css),
+    };
+
+    if (isNew) {
+      const id = await add({
+        name: sanitized.name || `Componente ${components.length + 1}`,
+        html: sanitized.html,
+        css: sanitized.css,
+        js: sanitized.js,
+      });
+      setIsNew(false);
+      setCurrent({ ...sanitized, id });
+    } else {
+      await update(sanitized);
+      setCurrent(sanitized);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Componente</Label>
+        <Select value={current?.id || (isNew ? NEW_VALUE : "")} onValueChange={handleSelect}>
+          <SelectTrigger>
+            <SelectValue placeholder="Escolha ou crie" />
+          </SelectTrigger>
+          <SelectContent>
+            {components.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+            <SelectItem value={NEW_VALUE}>Novo componente...</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {current && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="cc-name">Nome</Label>
+            <Input
+              id="cc-name"
+              value={current.name}
+              onChange={(e) => setCurrent({ ...current, name: e.target.value })}
+              placeholder="Nome do componente"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cc-html">HTML</Label>
+            <Textarea
+              id="cc-html"
+              rows={3}
+              value={current.html}
+              onChange={(e) => setCurrent({ ...current, html: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cc-css">CSS</Label>
+            <Textarea
+              id="cc-css"
+              rows={3}
+              value={current.css}
+              onChange={(e) => setCurrent({ ...current, css: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cc-js">JS</Label>
+            <Textarea
+              id="cc-js"
+              rows={3}
+              value={current.js}
+              onChange={(e) => setCurrent({ ...current, js: e.target.value })}
+            />
+          </div>
+          <Button size="sm" onClick={handleSave}>
+            {isNew ? "Criar" : "Atualizar"} componente
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+
+import { cn } from "@/utils/cn";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/pages/CustomComponents.tsx
+++ b/src/pages/CustomComponents.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Home,
@@ -9,18 +8,7 @@ import {
   BarChart3,
 } from "lucide-react";
 import { Button } from "../components/ui/button";
-import { Input } from "../components/ui/input";
-import { Textarea } from "../components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../components/ui/select";
-import { Label } from "../components/ui/label";
-import type { CustomComponent } from "../types/flow";
-import { useCustomComponents } from "../hooks/useCustomComponents";
+import CustomComponentManager from "../components/CustomComponentManager";
 
 interface NavItemProps {
   to: string;
@@ -45,80 +33,7 @@ function NavItem({ to, icon, label, active }: NavItemProps) {
   );
 }
 
-function sanitizeHtml(html: string) {
-  const template = document.createElement("template");
-  template.innerHTML = html;
-  for (const script of template.content.querySelectorAll("script")) {
-    script.remove();
-  }
-  for (const element of template.content.querySelectorAll("*")) {
-    for (const attr of Array.from(element.attributes)) {
-      if (attr.name.startsWith("on")) {
-        element.removeAttribute(attr.name);
-      }
-    }
-  }
-  return template.innerHTML;
-}
-
-function sanitizeCss(css: string) {
-  return css.replace(/<[^>]*>?/gm, "");
-}
-
-const NEW_VALUE = "__NEW__";
-
 export default function CustomComponents() {
-  const { components, load, add, update } = useCustomComponents();
-  const [current, setCurrent] = useState<CustomComponent | null>(null);
-  const [isNew, setIsNew] = useState(false);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const DEFAULT_COMPONENT: CustomComponent = {
-    id: "",
-    name: "Novo componente",
-    html: "",
-    css: "",
-    js: "",
-  };
-
-  const handleSelect = (value: string) => {
-    if (value === NEW_VALUE || value === "") {
-      setCurrent(DEFAULT_COMPONENT);
-      setIsNew(true);
-    } else {
-      const comp = components.find((c) => c.id === value) || DEFAULT_COMPONENT;
-      setCurrent(comp);
-      setIsNew(false);
-    }
-  };
-
-  const handleSave = async () => {
-    if (!current) return;
-
-    const sanitized = {
-      ...current,
-      html: sanitizeHtml(current.html),
-      css: sanitizeCss(current.css),
-    };
-
-    if (isNew) {
-      const id = await add({
-        name: sanitized.name || `Componente ${components.length + 1}`,
-        html: sanitized.html,
-        css: sanitized.css,
-        js: sanitized.js,
-      });
-      setIsNew(false);
-      setCurrent({ ...sanitized, id });
-    } else {
-      await update(sanitized);
-      setCurrent(sanitized);
-    }
-  };
-
   return (
     <div className="flex min-h-screen">
       <aside className="w-56 border-r p-4 space-y-2">
@@ -141,71 +56,8 @@ export default function CustomComponents() {
 
       <main className="flex-1 p-6 space-y-6">
         <h1 className="text-2xl font-bold">Componentes</h1>
-
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Componente</Label>
-            <Select value={current?.id || (isNew ? NEW_VALUE : "")} onValueChange={handleSelect}>
-              <SelectTrigger>
-                <SelectValue placeholder="Escolha ou crie" />
-              </SelectTrigger>
-              <SelectContent>
-                {components.map((c) => (
-                  <SelectItem key={c.id} value={c.id}>
-                    {c.name}
-                  </SelectItem>
-                ))}
-                <SelectItem value={NEW_VALUE}>Novo componente...</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {current && (
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="cc-name">Nome</Label>
-                <Input
-                  id="cc-name"
-                  value={current.name}
-                  onChange={(e) => setCurrent({ ...current, name: e.target.value })}
-                  placeholder="Nome do componente"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="cc-html">HTML</Label>
-                <Textarea
-                  id="cc-html"
-                  rows={3}
-                  value={current.html}
-                  onChange={(e) => setCurrent({ ...current, html: e.target.value })}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="cc-css">CSS</Label>
-                <Textarea
-                  id="cc-css"
-                  rows={3}
-                  value={current.css}
-                  onChange={(e) => setCurrent({ ...current, css: e.target.value })}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="cc-js">JS</Label>
-                <Textarea
-                  id="cc-js"
-                  rows={3}
-                  value={current.js}
-                  onChange={(e) => setCurrent({ ...current, js: e.target.value })}
-                />
-              </div>
-              <Button size="sm" onClick={handleSave}>
-                {isNew ? "Criar" : "Atualizar"} componente
-              </Button>
-            </div>
-          )}
-        </div>
+        <CustomComponentManager />
       </main>
     </div>
   );
 }
-

--- a/src/pages/FlowEditor/StepForm/Custom.tsx
+++ b/src/pages/FlowEditor/StepForm/Custom.tsx
@@ -4,6 +4,12 @@ import { Label } from "../../../components/ui/label";
 import { Textarea } from "../../../components/ui/textarea";
 import { Button } from "../../../components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../../../components/ui/dialog";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -45,6 +51,7 @@ export default function CustomStepForm({ step, setField }: Props) {
   const { components, load, add, update } = useCustomComponents();
   const [current, setCurrent] = useState<CustomComponent | null>(null);
   const [isNew, setIsNew] = useState(false);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     load();
@@ -105,77 +112,94 @@ export default function CustomStepForm({ step, setField }: Props) {
       await update(sanitized);
       setCurrent(sanitized);
     }
+    setOpen(false);
   };
 
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">Componente</Label>
-        <Select
-          value={step.componentId || (isNew ? NEW_VALUE : "")}
-          onValueChange={handleSelect}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Escolha ou crie" />
-          </SelectTrigger>
-          <SelectContent>
-            {components.map((c) => (
-              <SelectItem key={c.id} value={c.id}>
-                {c.name}
-              </SelectItem>
-            ))}
-            <SelectItem value={NEW_VALUE}>Novo componente...</SelectItem>
-          </SelectContent>
-        </Select>
+      <div className="flex items-end gap-2">
+        <div className="flex-1 space-y-2">
+          <Label className="text-sm font-medium">Componente</Label>
+          <Select
+            value={step.componentId || (isNew ? NEW_VALUE : "")}
+            onValueChange={handleSelect}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Escolha ou crie" />
+            </SelectTrigger>
+            <SelectContent>
+              {components.map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {c.name}
+                </SelectItem>
+              ))}
+              <SelectItem value={NEW_VALUE}>Novo componente...</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+          {isNew || !step.componentId ? "Criar" : "Editar"}
+        </Button>
       </div>
 
-      {current && (
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="cc-name">Nome</Label>
-            <Input
-              id="cc-name"
-              value={current.name}
-              onChange={(e) =>
-                setCurrent({ ...current, name: e.target.value })
-              }
-              placeholder="Nome do componente"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="cc-html">HTML</Label>
-            <Textarea
-              id="cc-html"
-              rows={3}
-              value={current.html}
-              onChange={(e) =>
-                setCurrent({ ...current, html: e.target.value })
-              }
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="cc-css">CSS</Label>
-            <Textarea
-              id="cc-css"
-              rows={3}
-              value={current.css}
-              onChange={(e) => setCurrent({ ...current, css: e.target.value })}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="cc-js">JS</Label>
-            <Textarea
-              id="cc-js"
-              rows={3}
-              value={current.js}
-              onChange={(e) => setCurrent({ ...current, js: e.target.value })}
-            />
-          </div>
-          <Button size="sm" onClick={handleSave}>
-            {isNew ? "Criar" : "Atualizar"} componente
-          </Button>
-        </div>
-      )}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{isNew ? "Novo Componente" : "Editar Componente"}</DialogTitle>
+          </DialogHeader>
+          {current && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="cc-name">Nome</Label>
+                <Input
+                  id="cc-name"
+                  value={current.name}
+                  onChange={(e) =>
+                    setCurrent({ ...current, name: e.target.value })
+                  }
+                  placeholder="Nome do componente"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cc-html">HTML</Label>
+                <Textarea
+                  id="cc-html"
+                  rows={3}
+                  value={current.html}
+                  onChange={(e) =>
+                    setCurrent({ ...current, html: e.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cc-css">CSS</Label>
+                <Textarea
+                  id="cc-css"
+                  rows={3}
+                  value={current.css}
+                  onChange={(e) =>
+                    setCurrent({ ...current, css: e.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cc-js">JS</Label>
+                <Textarea
+                  id="cc-js"
+                  rows={3}
+                  value={current.js}
+                  onChange={(e) =>
+                    setCurrent({ ...current, js: e.target.value })
+                  }
+                />
+              </div>
+              <Button size="sm" onClick={handleSave}>
+                {isNew ? "Criar" : "Atualizar"} componente
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,6 +17,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "../components/ui/tabs";
+import CustomComponentManager from "../components/CustomComponentManager";
 
 interface NavItemProps {
   to: string;
@@ -70,9 +72,16 @@ export default function Settings() {
       </aside>
 
       <main className="flex-1 p-6 space-y-6">
-        <h1 className="text-2xl font-bold">Seu perfil</h1>
+        <h1 className="text-2xl font-bold">Configurações</h1>
 
-        <section className="flex items-center gap-4">
+        <Tabs defaultValue="profile">
+          <TabsList>
+            <TabsTrigger value="profile">Perfil</TabsTrigger>
+            <TabsTrigger value="components">Componentes</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="profile" className="space-y-6">
+            <section className="flex items-center gap-4">
           <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center">
             <User className="h-8 w-8 text-muted-foreground" />
           </div>
@@ -86,7 +95,7 @@ export default function Settings() {
           </div>
         </section>
 
-        <section className="bg-background rounded-md shadow p-4 space-y-4">
+            <section className="bg-background rounded-md shadow p-4 space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Nome</label>
             <Input placeholder="Seu nome" />
@@ -97,7 +106,7 @@ export default function Settings() {
           </div>
         </section>
 
-        <section className="bg-background rounded-md shadow p-4 space-y-2">
+            <section className="bg-background rounded-md shadow p-4 space-y-2">
           <label className="block text-sm font-medium mb-1">Uso do sistema</label>
           <Select>
             <SelectTrigger className="w-48">
@@ -113,7 +122,7 @@ export default function Settings() {
           </p>
         </section>
 
-        <section className="pt-4 border-t">
+            <section className="pt-4 border-t">
           <h2 className="font-semibold mb-3">Contas conectadas</h2>
           <div className="flex items-center justify-between rounded-md border p-3">
             <span>Google</span>
@@ -123,12 +132,12 @@ export default function Settings() {
           </div>
         </section>
 
-        <section className="pt-4 border-t">
-          <h2 className="font-semibold mb-3">Componentes personalizados</h2>
-          <Button asChild size="sm" variant="outline">
-            <Link to="/components">Gerenciar componentes</Link>
-          </Button>
-        </section>
+          </TabsContent>
+
+          <TabsContent value="components" className="space-y-6">
+            <CustomComponentManager />
+          </TabsContent>
+        </Tabs>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add dialog component for generic modals
- refactor custom component CRUD into `CustomComponentManager`
- update custom components page to use new manager
- add components tab to Settings with CRUD UI
- open modal in step form for creating and editing components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aa95065188322842ce3bb2336fa3f