### PR TITLE
Persist dashboard card settings

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 import Dexie from "dexie";
 import type { Table } from "dexie";
 import type { Flow, LogEntry, Session, StepEvent, PauseEvent, CustomComponent } from "../types/flow";
+import type { DashboardSettings } from "../types/settings";
 
 class TacoDB extends Dexie {
   flows!: Table<Flow, string>;
@@ -9,6 +10,7 @@ class TacoDB extends Dexie {
   pauseEvents!: Table<PauseEvent, string>;
   logs!: Table<LogEntry, string>;
   customComponents!: Table<CustomComponent, string>;
+  settings!: Table<DashboardSettings, string>;
 
   constructor() {
     super("taco");
@@ -21,6 +23,17 @@ class TacoDB extends Dexie {
       pauseEvents: "id, sessionId, stepId, pausedAt, resumedAt",
       logs: "id, ts, actor, action, flowId, stepId",
       customComponents: "id, name",
+    });
+
+    this.version(2).stores({
+      flows: "id, title, status, updatedAt",
+      sessions:
+        "id, flowId, startedAt, finishedAt, currentIndex, isPaused",
+      stepEvents: "id, sessionId, stepId, enterAt, leaveAt",
+      pauseEvents: "id, sessionId, stepId, pausedAt, resumedAt",
+      logs: "id, ts, actor, action, flowId, stepId",
+      customComponents: "id, name",
+      settings: "id",
     });
   }
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -102,6 +102,30 @@ export default function Dashboard() {
   const [showCompletionRate, setShowCompletionRate] = useState(true);
   const [showStepCount, setShowStepCount] = useState(true);
 
+  // Load persisted settings
+  useEffect(() => {
+    (async () => {
+      const saved = await db.settings.get("dashboard");
+      if (saved) {
+        setShowVisits(saved.showVisits);
+        setShowCompletions(saved.showCompletions);
+        setShowCompletionRate(saved.showCompletionRate);
+        setShowStepCount(saved.showStepCount);
+      }
+    })();
+  }, []);
+
+  // Persist settings whenever they change
+  useEffect(() => {
+    db.settings.put({
+      id: "dashboard",
+      showVisits,
+      showCompletions,
+      showCompletionRate,
+      showStepCount,
+    });
+  }, [showVisits, showCompletions, showCompletionRate, showStepCount]);
+
   useEffect(() => {
     load();
   }, [load]);

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,7 @@
+export interface DashboardSettings {
+  id: string;
+  showVisits: boolean;
+  showCompletions: boolean;
+  showCompletionRate: boolean;
+  showStepCount: boolean;
+}


### PR DESCRIPTION
## Summary
- add DashboardSettings interface and DB table
- load and persist card settings in Dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686aa8b62b0c8322bdbd9aaaf0f06f10