### PR TITLE
Fix FlowPlayer height

### DIFF
--- a/src/pages/FlowPlayer/Skeleton.tsx
+++ b/src/pages/FlowPlayer/Skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "../../components/ui/skeleton";
 
 export default function PlayerSkeleton() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-blue-50 via-white to-purple-50">
       {/* Header Skeleton */}
       <header className="bg-white/80 backdrop-blur-sm border-b">
         <div className="max-w-4xl mx-auto px-4 py-4">

--- a/src/pages/FlowPlayer/index.tsx
+++ b/src/pages/FlowPlayer/index.tsx
@@ -135,7 +135,7 @@ export default function FlowPlayer() {
   const progressPercentage = progress * 100;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-blue-50 via-white to-purple-50">
       <PlayerHeader
         flowTitle={flow.title}
         current={current}


### PR DESCRIPTION
## Summary
- ensure FlowPlayer pages use a flex column layout so the header and content fill the viewport

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aacde7de0832280c7e8d96e2c146d