### PR TITLE
Persist dashboard view mode

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -74,18 +74,6 @@ export default function Dashboard() {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
-  // Load view mode preference from localStorage on mount
-  useEffect(() => {
-    const saved = localStorage.getItem("taco-dashboard-view");
-    if (saved === "grid" || saved === "list") {
-      setViewMode(saved as ViewMode);
-    }
-  }, []);
-
-  // Persist view mode preference to localStorage whenever it changes
-  useEffect(() => {
-    localStorage.setItem("taco-dashboard-view", viewMode);
-  }, [viewMode]);
   const [isCreating, setIsCreating] = useState(false);
   const [isSelecting, setIsSelecting] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -111,20 +99,30 @@ export default function Dashboard() {
         setShowCompletions(saved.showCompletions);
         setShowCompletionRate(saved.showCompletionRate);
         setShowStepCount(saved.showStepCount);
+        if (saved.viewMode === "grid" || saved.viewMode === "list") {
+          setViewMode(saved.viewMode);
+        }
+      } else {
+        const local = localStorage.getItem("taco-dashboard-view");
+        if (local === "grid" || local === "list") {
+          setViewMode(local as ViewMode);
+        }
       }
     })();
   }, []);
 
   // Persist settings whenever they change
   useEffect(() => {
+    localStorage.setItem("taco-dashboard-view", viewMode);
     db.settings.put({
       id: "dashboard",
+      viewMode,
       showVisits,
       showCompletions,
       showCompletionRate,
       showStepCount,
     });
-  }, [showVisits, showCompletions, showCompletionRate, showStepCount]);
+  }, [viewMode, showVisits, showCompletions, showCompletionRate, showStepCount]);
 
   useEffect(() => {
     load();

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,6 @@
 export interface DashboardSettings {
   id: string;
+  viewMode: "grid" | "list";
   showVisits: boolean;
   showCompletions: boolean;
   showCompletionRate: boolean;


### PR DESCRIPTION
## Summary
- persist `viewMode` in Dashboard settings table
- update Dashboard settings type to include `viewMode`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686ab17473148322a0f397b540e6dcd0