### PR TITLE
Improve mobile chart labels

### DIFF
--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export default function useIsMobile(breakpoint = 640) {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== "undefined" ? window.innerWidth < breakpoint : false
+  );
+
+  useEffect(() => {
+    const onResize = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/src/pages/Analytics/StackedAreaChart.tsx
+++ b/src/pages/Analytics/StackedAreaChart.tsx
@@ -1,4 +1,5 @@
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts";
+import useIsMobile from "../../hooks/use-is-mobile";
 import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
 
 interface StepInfo {
@@ -18,6 +19,7 @@ interface Props {
 }
 
 export default function StackedAreaChart({ data, steps, colors }: Props) {
+  const isMobile = useIsMobile();
   return (
     <Card>
       <CardHeader>
@@ -31,10 +33,14 @@ export default function StackedAreaChart({ data, steps, colors }: Props) {
               margin={{ top: 20, right: 20, left: 20, bottom: 20 }}
             >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" fontSize={window.innerWidth < 640 ? 10 : 12} />
-              <YAxis unit="s" fontSize={window.innerWidth < 640 ? 10 : 12} />
+              <XAxis dataKey="name" fontSize={isMobile ? 10 : 12} />
+              <YAxis unit="s" fontSize={isMobile ? 10 : 12} />
               <Tooltip formatter={(v: number) => `${v}s`} />
-              <Legend />
+              <Legend
+                verticalAlign="bottom"
+                align="center"
+                wrapperStyle={{ paddingTop: 8 }}
+              />
               {steps.map((step, idx) => (
                 <Area
                   key={step.id}

--- a/src/pages/Analytics/TimelineChart.tsx
+++ b/src/pages/Analytics/TimelineChart.tsx
@@ -1,4 +1,5 @@
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
+import useIsMobile from "../../hooks/use-is-mobile";
 import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
 
 interface StepInfo {
@@ -18,6 +19,7 @@ interface Props {
 }
 
 export default function TimelineChart({ data, steps, colors }: Props) {
+  const isMobile = useIsMobile();
   return (
     <Card>
       <CardHeader>
@@ -30,21 +32,25 @@ export default function TimelineChart({ data, steps, colors }: Props) {
               data={data}
               layout="vertical"
               margin={{
-                left: window.innerWidth < 640 ? 60 : 80,
+                left: isMobile ? 60 : 80,
                 right: 20,
                 top: 20,
                 bottom: 20,
               }}
             >
-              <XAxis type="number" unit="s" fontSize={window.innerWidth < 640 ? 10 : 12} />
+              <XAxis type="number" unit="s" fontSize={isMobile ? 10 : 12} />
               <YAxis
                 type="category"
                 dataKey="name"
-                width={window.innerWidth < 640 ? 60 : 100}
-                fontSize={window.innerWidth < 640 ? 9 : 11}
+                width={isMobile ? 60 : 100}
+                fontSize={isMobile ? 9 : 11}
               />
               <Tooltip formatter={(v: number) => `${v}s`} />
-              <Legend />
+              <Legend
+                verticalAlign="bottom"
+                align="center"
+                wrapperStyle={{ paddingTop: 8 }}
+              />
               {steps.map((step, idx) => (
                 <Bar
                   key={step.id}


### PR DESCRIPTION
## Summary
- add hook to detect mobile screens
- ensure timeline and stacked area charts adapt to mobile width
- keep the legends always at the bottom

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_686ab20fa03c8322b54e451c20a7fcde