### PR TITLE
Add YouTube embed support

### DIFF
--- a/src/pages/FlowEditor/StepForm/Media.tsx
+++ b/src/pages/FlowEditor/StepForm/Media.tsx
@@ -2,6 +2,7 @@ import { Input } from "../../../components/ui/input";
 import { Label } from "../../../components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../components/ui/select";
 import type { Step } from "../../../types/flow";
+import { getYouTubeEmbedUrl } from "../../../utils/youtube";
 
 interface Props {
   step: Step;
@@ -17,7 +18,7 @@ export default function MediaStepForm({ step, setField }: Props) {
           id="media-url"
           value={step.mediaUrl || ""}
           onChange={(e) => setField("mediaUrl", e.target.value)}
-          placeholder="https://exemplo.com/arquivo.png"
+          placeholder="https://exemplo.com/arquivo.png ou https://youtu.be/xyz"
         />
       </div>
       <div className="space-y-2">
@@ -32,14 +33,23 @@ export default function MediaStepForm({ step, setField }: Props) {
           <SelectContent>
             <SelectItem value="image">Imagem</SelectItem>
             <SelectItem value="video">Vídeo</SelectItem>
+            <SelectItem value="youtube">YouTube</SelectItem>
           </SelectContent>
-        </Select>
-      </div>
+      </Select>
+    </div>
       {step.mediaUrl && step.mediaType === "image" && (
         <img src={step.mediaUrl} alt="preview" className="max-h-60 mx-auto" />
       )}
       {step.mediaUrl && step.mediaType === "video" && (
         <video src={step.mediaUrl} controls className="max-h-60 mx-auto" />
+      )}
+      {step.mediaUrl && step.mediaType === "youtube" && (
+        <iframe
+          src={getYouTubeEmbedUrl(step.mediaUrl)}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="w-full max-h-60 mx-auto"
+        />
       )}
     </div>
   );

--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -28,6 +28,7 @@ import {
 import { Badge } from "../../../components/ui/badge";
 import { Alert, AlertDescription } from "../../../components/ui/alert";
 import { cn } from "../../../utils/cn";
+import { getYouTubeEmbedUrl } from "../../../utils/youtube";
 
 import TextStepForm from "./Text";
 import QuestionStepForm from "./Question";
@@ -333,6 +334,13 @@ function StepPreview({ step, onExitPreview }: StepPreviewProps) {
                   src={step.mediaUrl}
                   controls
                   className="mx-auto mb-8 max-h-96"
+                />
+              ) : step.mediaType === "youtube" ? (
+                <iframe
+                  src={getYouTubeEmbedUrl(step.mediaUrl)}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  className="w-full mx-auto mb-8 max-h-96"
                 />
               ) : (
                 <img

--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -11,6 +11,7 @@ import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { Badge } from "../../components/ui/badge";
 import { cn } from "../../utils/cn";
+import { getYouTubeEmbedUrl } from "../../utils/youtube";
 import CustomRenderer from "../../components/CustomRenderer";
 import Markdown from "../../components/Markdown";
 import { parseInlineMarkdown } from "../../utils/markdown";
@@ -102,6 +103,13 @@ export default function StepCard({
                     src={step.mediaUrl}
                     controls
                     className="mx-auto mb-6 max-h-96"
+                  />
+                ) : step.mediaType === "youtube" ? (
+                  <iframe
+                    src={getYouTubeEmbedUrl(step.mediaUrl)}
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                    className="w-full mx-auto mb-6 max-h-96"
                   />
                 ) : (
                   <img

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -33,7 +33,7 @@ export interface Step {
   /** URL de imagem ou vídeo para passos do tipo MEDIA */
   mediaUrl?: string;
   /** Tipo da mídia associada */
-  mediaType?: "image" | "video";
+  mediaType?: "image" | "video" | "youtube";
   /** ID do passo para o qual este passo deve redirecionar. Se vazio, finaliza o fluxo. */
   nextStepId?: string;
   options?: StepOption[];

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -1,0 +1,5 @@
+export function getYouTubeEmbedUrl(url: string): string {
+  const match = url.match(/(?:youtube\.com\/(?:.*v=|v\/|embed\/)|youtu\.be\/)([A-Za-z0-9_-]{11})/);
+  const id = match ? match[1] : url;
+  return `https://www.youtube.com/embed/${id}`;
+}


### PR DESCRIPTION
## Summary
- support `youtube` media type in Flow step types
- embed YouTube preview in StepForm
- render YouTube videos in FlowPlayer
- add helper to transform YouTube URLs into embed links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ab96711988322a2aafd191c9acc3a