### PR TITLE
Add company customization page

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   BarChart3,
   User,
+  Building2,
   Menu,
 } from "lucide-react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -31,6 +32,7 @@ const navItems: NavItem[] = [
   { to: "/import-export", icon: <FileText className="h-4 w-4" />, label: "Import/Export" },
   { to: "/path-analytics", icon: <BarChart3 className="h-4 w-4" />, label: "Path Analytics" },
   { to: "/components", icon: <User className="h-4 w-4" />, label: "Componentes" },
+  { to: "/company", icon: <Building2 className="h-4 w-4" />, label: "Empresa" },
 ];
 
 function NavItemLink({ to, icon, label }: NavItem) {

--- a/src/hooks/useCompanySettings.ts
+++ b/src/hooks/useCompanySettings.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export interface CompanySettings {
+  logo: string | null;
+  primary: string;
+  secondary: string;
+  setLogo: (logo: string | null) => void;
+  setPrimary: (color: string) => void;
+  setSecondary: (color: string) => void;
+}
+
+export const useCompanySettings = create<CompanySettings>()(
+  persist(
+    (set) => ({
+      logo: null,
+      primary: "#0a0a0a",
+      secondary: "#f3f3f3",
+      setLogo: (logo) => set({ logo }),
+      setPrimary: (color) => set({ primary: color }),
+      setSecondary: (color) => set({ secondary: color }),
+    }),
+    { name: "taco-company-settings" }
+  )
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vite-plugin-pwa/client" />
 
-import { StrictMode } from "react";
+import { StrictMode, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 
@@ -12,15 +12,23 @@ import FlowPlayer from "./pages/FlowPlayer";
 import Analytics from "./pages/Analytics";
 import FlowEditor from "./pages/FlowEditor";
 import Settings from "./pages/Settings";
+import Company from "./pages/Company";
 import Audit from "./pages/Audit";
 import ImportExport from "./pages/ImportExport";
 import PathAnalytics from "./pages/PathAnalytics";
 import CustomComponents from "./pages/CustomComponents";
+import { useCompanySettings } from "./hooks/useCompanySettings";
+import { applyBrandColors } from "./utils/theme";
 
 registerSW({ immediate: true });
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
+function App() {
+  const { primary, secondary } = useCompanySettings();
+  useEffect(() => {
+    applyBrandColors(primary, secondary);
+  }, [primary, secondary]);
+
+  return (
     <BrowserRouter>
       <Routes>
         {/* Home - lista todos os fluxos */}
@@ -37,6 +45,8 @@ createRoot(document.getElementById("root")!).render(
 
         {/* Configurações do usuário */}
         <Route path="/settings" element={<Settings />} />
+        {/* Configurações da empresa */}
+        <Route path="/company" element={<Company />} />
 
         {/* Log de auditoria */}
         <Route path="/audit" element={<Audit />} />
@@ -54,5 +64,11 @@ createRoot(document.getElementById("root")!).render(
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
   </StrictMode>
 );

--- a/src/pages/Company.tsx
+++ b/src/pages/Company.tsx
@@ -1,0 +1,58 @@
+import { useRef, ChangeEvent } from "react";
+import SidebarLayout from "../components/Sidebar";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { useCompanySettings } from "../hooks/useCompanySettings";
+
+export default function Company() {
+  const { logo, primary, secondary, setLogo, setPrimary, setSecondary } =
+    useCompanySettings();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const onFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setLogo(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <SidebarLayout title="Empresa">
+      <div className="space-y-6 max-w-md">
+        <div className="space-y-2">
+          <Label>Logo</Label>
+          {logo && (
+            <img src={logo} alt="Logo" className="h-20 object-contain" />
+          )}
+          <Input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            onChange={onFileChange}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Cor Primária</Label>
+          <Input
+            type="color"
+            value={primary}
+            onChange={(e) => setPrimary(e.target.value)}
+            className="w-20 h-10 p-1"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Cor Secundária</Label>
+          <Input
+            type="color"
+            value={secondary}
+            onChange={(e) => setSecondary(e.target.value)}
+            className="w-20 h-10 p-1"
+          />
+        </div>
+      </div>
+    </SidebarLayout>
+  );
+}

--- a/src/pages/Dashboard/Header.tsx
+++ b/src/pages/Dashboard/Header.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Plus, Upload, Settings } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
+import { useCompanySettings } from "../../hooks/useCompanySettings";
 
 interface Props {
   onNew: () => void;
@@ -24,9 +25,13 @@ export default function DashboardHeader({
   onImport,
   isImporting,
 }: Props) {
+  const { logo } = useCompanySettings();
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
       <div className="flex flex-col items-start">
+        {logo && (
+          <img src={logo} alt="Logo" className="h-8 mb-2" />
+        )}
         <h1 className="text-3xl font-bold tracking-tight">Meus Fluxos</h1>
         <p className="text-muted-foreground">Gerencie e monitore seus fluxos de trabalho</p>
       </div>

--- a/src/pages/FlowPlayer/Header.tsx
+++ b/src/pages/FlowPlayer/Header.tsx
@@ -13,6 +13,7 @@ import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Progress } from "../../components/ui/progress";
 import { Clock, Pause, Play, ArrowLeft } from "lucide-react";
+import { useCompanySettings } from "../../hooks/useCompanySettings";
 
 interface Props {
   flowTitle: string;
@@ -37,6 +38,7 @@ export default function PlayerHeader({
   onPauseResume,
   onExit,
 }: Props) {
+  const { logo } = useCompanySettings();
   return (
     <header className="bg-white/80 backdrop-blur-sm border-b sticky top-0 z-10">
       <div className="max-w-4xl mx-auto px-4 py-4">
@@ -67,6 +69,7 @@ export default function PlayerHeader({
             </AlertDialog>
 
             <div className="hidden sm:block">
+              {logo && <img src={logo} alt="Logo" className="h-6 mb-1" />}
               <h1 className="font-semibold text-lg">{flowTitle}</h1>
               <p className="text-sm text-muted-foreground">
                 Passo {current} de {total}

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,36 @@
+export function hexToHsl(hex: string): string {
+  let c = hex.replace('#', '');
+  if (c.length === 3) {
+    c = c.split('').map((x) => x + x).join('');
+  }
+  const r = parseInt(c.substring(0, 2), 16) / 255;
+  const g = parseInt(c.substring(2, 4), 16) / 255;
+  const b = parseInt(c.substring(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+  return `${Math.round(h)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+}
+
+export function applyBrandColors(primary: string, secondary: string) {
+  document.documentElement.style.setProperty('--primary', hexToHsl(primary));
+  document.documentElement.style.setProperty('--secondary', hexToHsl(secondary));
+}


### PR DESCRIPTION
## Summary
- add company brand settings hook
- apply brand colors globally
- support company logo in dashboard and FlowPlayer
- expose new Empresa page in sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686abb9fa2848322b8adab9d2bead886