### PR TITLE
Fix stacked area chart title

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -348,7 +348,12 @@ export default function Analytics() {
         <PauseHeatmap pauseRuns={pauseRuns} steps={steps} maxCount={maxPause} />
 
         {/* Stacked Area Chart */}
-        <StackedAreaChart data={areaData} steps={steps} colors={COLORS} />
+        <StackedAreaChart
+          data={areaData}
+          steps={steps}
+          colors={COLORS}
+          runsToShow={runsToShow}
+        />
 
         {/* Network Graph */}
         <NetworkGraph flow={f} />

--- a/src/pages/Analytics/StackedAreaChart.tsx
+++ b/src/pages/Analytics/StackedAreaChart.tsx
@@ -25,16 +25,24 @@ interface Props {
   data: ChartRow[];
   steps: StepInfo[];
   colors: string[];
+  runsToShow: number | "all";
 }
 
-export default function StackedAreaChart({ data, steps, colors }: Props) {
+export default function StackedAreaChart({
+  data,
+  steps,
+  colors,
+  runsToShow,
+}: Props) {
   const isMobile = useIsMobile();
 
   return (
     <Card className="w-full">
       <CardHeader className="pb-4">
         <CardTitle className="text-base sm:text-lg md:text-xl text-center sm:text-left">
-          Área Empilhada – Últimas 5
+          {`Área Empilhada – ${
+            runsToShow === "all" ? "Todas" : `Últimas ${runsToShow}`
+          }`}
         </CardTitle>
       </CardHeader>
       <CardContent className="p-3 sm:p-6">


### PR DESCRIPTION
## Summary
- show dynamic session count in the stacked area chart header
- pass runsToShow to the stacked area chart

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686aceeaacb0832289959bc215cf0db4