### PR TITLE
Add AI assistant instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,6 @@ export default tseslint.config([
   },
 ])
 ```
+
+## AI powered flows
+To enable the AI assistant for flow creation, set `VITE_OPENAI_API_KEY` in a `.env` file with your OpenAI API key.

--- a/src/components/dashboard/AIFlowModal.tsx
+++ b/src/components/dashboard/AIFlowModal.tsx
@@ -9,12 +9,17 @@ interface Props {
   onImport: (json: string) => Promise<void>;
 }
 
-const SYSTEM_PROMPT = `Você é o assistente de IA do TACO – Task Companion.\n\n` +
-  `A plataforma permite criar fluxos de passos interativos com os tipos TEXT, QUESTION, MEDIA, CUSTOM e WEBHOOK.\n` +
-  `Quando o usuário pedir para criar um fluxo, explique resumidamente o que será feito e pergunte se está correto.\n` +
-  `Aguarde a confirmação do usuário antes de gerar o JSON.\n` +
-  `Quando for gerado, produza apenas um bloco de código JSON com a estrutura:\n` +
-  `\n{\n  "version": "1.0",\n  "exportedAt": 0,\n  "flow": {\n    "title": "Titulo do fluxo",\n    "description": "Opcional",\n    "status": "DRAFT",\n    "steps": [/* passos aqui */]\n  }\n}`;
+const SYSTEM_PROMPT = `Você é o assistente virtual do TACO – Task Companion.\n\n` +
+  `Explique de forma amigável que a plataforma cria fluxos com passos dos tipos ` +
+  `TEXT, QUESTION, MEDIA, CUSTOM e WEBHOOK. Responda dúvidas normalmente e ` +
+  `sugira ao usuário experimentar a criação de um fluxo a partir de uma ` +
+  `descrição.\n\n` +
+  `Quando o usuário descrever um fluxo, analise a ideia e apresente um resumo ` +
+  `dos passos que pretende gerar. Pergunte se está correto ou se deseja ajustes ` +
+  `e espere pela confirmação. Somente após a confirmação gere o JSON final.\n\n` +
+  `Envie o JSON em um único bloco de código sem comentários e seguindo esta ` +
+  `estrutura:\n` +
+  `\n{\n  "version": "1.0",\n  "exportedAt": 0,\n  "flow": {\n    "title": "Título do fluxo",\n    "description": "Opcional",\n    "status": "DRAFT",\n    "steps": [/* passos aqui */]\n  }\n}`;
 
 export default function AIFlowModal({ open, onOpenChange, onImport }: Props) {
   const [messages, setMessages] = useState<{ role: "user" | "assistant"; content: string }[]>([]);


### PR DESCRIPTION
## Summary
- update AI assistant system prompt for better conversation
- document how to enable AI flows via env variable

## Testing
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686b3e654d4c832298603927949cc4dd