### PR TITLE
Fix session initialization

### DIFF
--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -46,7 +46,7 @@ export function usePlayer(flow?: Flow, loadSessionId?: string): PlayerState {
         const arr = await db.sessions
           .where("flowId")
           .equals(flow.id)
-          .filter((s) => !s.finishedAt && !!s.isPaused)
+          .filter((s) => !s.finishedAt)
           .toArray();
         if (arr.length) {
           existing = arr.sort((a, b) => b.startedAt - a.startedAt)[0];


### PR DESCRIPTION
## Summary
- fix session retrieval in usePlayer to consider any unfinished session

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b4e4137bc832297e01e5e34798b57