### PR TITLE
Enable dynamic analytics chart titles

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -339,13 +339,28 @@ export default function Analytics() {
         <TotalTimeChart data={totalByStepData} />
 
         {/* Timeline Horizontal */}
-        <TimelineChart data={timelineData} steps={steps} colors={COLORS} />
+        <TimelineChart
+          data={timelineData}
+          steps={steps}
+          colors={COLORS}
+          runsToShow={runsToShow}
+        />
 
         {/* Heatmap */}
-        <Heatmap recentRuns={recentRuns} steps={steps} maxDuration={allDur} />
+        <Heatmap
+          recentRuns={recentRuns}
+          steps={steps}
+          maxDuration={allDur}
+          runsToShow={runsToShow}
+        />
 
         {/* Pause Heatmap */}
-        <PauseHeatmap pauseRuns={pauseRuns} steps={steps} maxCount={maxPause} />
+        <PauseHeatmap
+          pauseRuns={pauseRuns}
+          steps={steps}
+          maxCount={maxPause}
+          runsToShow={runsToShow}
+        />
 
         {/* Stacked Area Chart */}
         <StackedAreaChart

--- a/src/pages/Analytics/Heatmap.tsx
+++ b/src/pages/Analytics/Heatmap.tsx
@@ -14,13 +14,25 @@ interface Props {
   recentRuns: SessionRun[];
   steps: StepInfo[];
   maxDuration: number;
+  runsToShow: number | "all";
 }
 
-export default function Heatmap({ recentRuns, steps, maxDuration }: Props) {
+export default function Heatmap({
+  recentRuns,
+  steps,
+  maxDuration,
+  runsToShow,
+}: Props) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-lg sm:text-xl">Heatmap de Tempo</CardTitle>
+        <CardTitle className="text-lg sm:text-xl">
+          {`Heatmap de Tempo – ${
+            runsToShow === "all"
+              ? "Todas as Execuções"
+              : `Últimas ${runsToShow} Execuções`
+          }`}
+        </CardTitle>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto">

--- a/src/pages/Analytics/PauseHeatmap.tsx
+++ b/src/pages/Analytics/PauseHeatmap.tsx
@@ -13,13 +13,25 @@ interface Props {
   pauseRuns: PauseRun[];
   steps: StepInfo[];
   maxCount: number;
+  runsToShow: number | "all";
 }
 
-export default function PauseHeatmap({ pauseRuns, steps, maxCount }: Props) {
+export default function PauseHeatmap({
+  pauseRuns,
+  steps,
+  maxCount,
+  runsToShow,
+}: Props) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-lg sm:text-xl">Heatmap de Pausas</CardTitle>
+        <CardTitle className="text-lg sm:text-xl">
+          {`Heatmap de Pausas – ${
+            runsToShow === "all"
+              ? "Todas as Execuções"
+              : `Últimas ${runsToShow} Execuções`
+          }`}
+        </CardTitle>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto">

--- a/src/pages/Analytics/TimelineChart.tsx
+++ b/src/pages/Analytics/TimelineChart.tsx
@@ -24,16 +24,21 @@ interface Props {
   data: ChartRow[];
   steps: StepInfo[];
   colors: string[];
+  runsToShow: number | "all";
 }
 
-export default function TimelineChart({ data, steps, colors }: Props) {
+export default function TimelineChart({ data, steps, colors, runsToShow }: Props) {
   const isMobile = useIsMobile();
 
   return (
     <Card className="w-full">
       <CardHeader className="pb-4">
         <CardTitle className="text-base sm:text-lg md:text-xl text-center sm:text-left">
-          Timeline – Últimas 5 Execuções
+          {`Timeline – ${
+            runsToShow === "all"
+              ? "Todas as Execuções"
+              : `Últimas ${runsToShow} Execuções`
+          }`}
         </CardTitle>
       </CardHeader>
       <CardContent className="p-3 sm:p-6">


### PR DESCRIPTION
## Summary
- display the selected number of executions in analytics chart titles
- pass `runsToShow` to Heatmap, PauseHeatmap and TimelineChart so they re-render correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: command could not run)*

------
https://chatgpt.com/codex/tasks/task_e_686b9794cf708322af55e446973796f7