### PR TITLE
Support exporting components with flows

### DIFF
--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -133,3 +133,14 @@ export interface LogEntry {
   stepId?: string;
   payload?: unknown;
 }
+
+/**
+ * Estrutura de dados para exportação/importação de fluxos
+ * juntamente com componentes customizados necessários.
+ */
+export interface FlowPackage {
+  version: string;
+  exportedAt: number;
+  flows: Omit<Flow, "id">[];
+  components: CustomComponent[];
+}


### PR DESCRIPTION
## Summary
- extend flow export format to include custom components
- update import logic to handle new package structure
- add `FlowPackage` type

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686b9ed0f3508322966c2122ad66f5f4