### PR TITLE
Fix step badge display for question and custom types

### DIFF
--- a/src/pages/FlowEditor.tsx
+++ b/src/pages/FlowEditor.tsx
@@ -45,8 +45,9 @@ import StepForm from "./FlowEditor/StepForm";
 
 const STEP_TYPES = {
   TEXT: { label: "Texto", color: "bg-blue-100 text-blue-800" },
-  FORM: { label: "Formulário", color: "bg-green-100 text-green-800" },
+  QUESTION: { label: "Pergunta", color: "bg-green-100 text-green-800" },
   MEDIA: { label: "Mídia", color: "bg-purple-100 text-purple-800" },
+  CUSTOM: { label: "Personalizado", color: "bg-orange-100 text-orange-800" },
 } as const;
 
 export default function FlowEditor() {


### PR DESCRIPTION
## Summary
- show correct badge labels and colors for question and custom step types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bb8573cbc8322ae32e3ef1d392e9f