### PR TITLE
Remove video media option

### DIFF
--- a/src/components/dashboard/AIFlowModal.tsx
+++ b/src/components/dashboard/AIFlowModal.tsx
@@ -49,7 +49,7 @@ Quando o usuário pedir para criar um fluxo, você deve:
 - Confirmar se há passos do tipo:
   - 📄 **TEXT**: exibe um texto.
   - ❓ **QUESTION**: possui opções com destino.
-  - 🎥 **MEDIA**: mostra um vídeo ou imagem.
+  - 🎥 **MEDIA**: mostra uma imagem ou vídeo do YouTube.
   - 🧩 **CUSTOM**: usa HTML/CSS/JS (via \`componentId\`).
   - 🌐 **WEBHOOK**: executa uma URL com método.
 
@@ -66,7 +66,7 @@ Antes de gerar o JSON final, **liste todos os passos** em texto para o usuário 
    • TP-Link → vai para 3  
    • Intelbras → vai para 4
 3. 📄 **Instruções TP-Link** – Instruções para configurar o roteador TP-Link.
-4. 🎥 **Vídeo Intelbras** – tipo: vídeo, URL: https://youtu.be/JxTq47bbx4g
+4. 🎥 **Tutorial Intelbras** – tipo: YouTube, URL: https://youtu.be/JxTq47bbx4g
 5. 🧩 **Painel** – usa componente visual personalizado (componentId: xyz123)
 
 Em seguida, pergunte:
@@ -102,7 +102,7 @@ Use exatamente este schema:
             }
           ],
           "nextStepId": <string>, // apenas para TEXT, MEDIA, CUSTOM, WEBHOOK
-          "mediaType": "video" | "image", // apenas para MEDIA
+          "mediaType": "image" | "youtube", // apenas para MEDIA
           "mediaUrl": <string>, // apenas para MEDIA
           "componentId": <string>, // apenas para CUSTOM
           "method": "GET" | "POST", // apenas para WEBHOOK

--- a/src/components/flow/StepForm.tsx
+++ b/src/components/flow/StepForm.tsx
@@ -65,7 +65,7 @@ const STEP_TYPES = [
   {
     value: "MEDIA",
     label: "Mídia",
-    description: "Imagens e vídeos",
+    description: "Imagens e YouTube",
     icon: ImageIcon,
     color: "bg-purple-50 text-purple-700 border-purple-200",
     disabled: true,

--- a/src/pages/FlowEditor/StepForm/Media.tsx
+++ b/src/pages/FlowEditor/StepForm/Media.tsx
@@ -32,16 +32,12 @@ export default function MediaStepForm({ step, setField }: Props) {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="image">Imagem</SelectItem>
-            <SelectItem value="video">Vídeo</SelectItem>
             <SelectItem value="youtube">YouTube</SelectItem>
           </SelectContent>
       </Select>
     </div>
       {step.mediaUrl && step.mediaType === "image" && (
         <img src={step.mediaUrl} alt="preview" className="max-h-60 mx-auto" />
-      )}
-      {step.mediaUrl && step.mediaType === "video" && (
-        <video src={step.mediaUrl} controls className="max-h-60 mx-auto" />
       )}
       {step.mediaUrl && step.mediaType === "youtube" && (
         <iframe

--- a/src/pages/FlowEditor/StepForm/index.tsx
+++ b/src/pages/FlowEditor/StepForm/index.tsx
@@ -63,7 +63,7 @@ const STEP_TYPES = [
   {
     value: "MEDIA",
     label: "Mídia",
-    description: "Imagens e vídeos",
+    description: "Imagens e YouTube",
     icon: ImageIcon,
     color: "bg-purple-50 text-purple-700 border-purple-200",
     disabled: false,
@@ -335,13 +335,7 @@ function StepPreview({ step, onExitPreview }: StepPreviewProps) {
             </h1>
             {step.type === "MEDIA" &&
               step.mediaUrl &&
-              (step.mediaType === "video" ? (
-                <video
-                  src={step.mediaUrl}
-                  controls
-                  className="mx-auto mb-8 max-h-96"
-                />
-              ) : step.mediaType === "youtube" ? (
+              (step.mediaType === "youtube" ? (
                 <iframe
                   src={getYouTubeEmbedUrl(step.mediaUrl)}
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/src/pages/FlowPlayer/StepCard.tsx
+++ b/src/pages/FlowPlayer/StepCard.tsx
@@ -53,13 +53,7 @@ export default function StepCard({
             {/* Step Content */}
             <div className="text-center">
               {step.type === "MEDIA" && step.mediaUrl && (
-                step.mediaType === "video" ? (
-                  <video
-                    src={step.mediaUrl}
-                    controls
-                    className="mx-auto mb-6 max-h-96"
-                  />
-                ) : step.mediaType === "youtube" ? (
+                step.mediaType === "youtube" ? (
                   <iframe
                     src={getYouTubeEmbedUrl(step.mediaUrl)}
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -30,10 +30,10 @@ export interface Step {
   type: "TEXT" | "QUESTION" | "MEDIA" | "CUSTOM";
   title: string;
   content: string;
-  /** URL de imagem ou vídeo para passos do tipo MEDIA */
+  /** URL de imagem ou vídeo do YouTube para passos do tipo MEDIA */
   mediaUrl?: string;
   /** Tipo da mídia associada */
-  mediaType?: "image" | "video" | "youtube";
+  mediaType?: "image" | "youtube";
   /** ID do passo para o qual este passo deve redirecionar. Se vazio, finaliza o fluxo. */
   nextStepId?: string;
   options?: StepOption[];


### PR DESCRIPTION
## Summary
- update AI assistant instructions to support only YouTube or images
- drop `video` choice from media forms and previews
- update flow types and labels accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bb8c0ed5c832296ff779441ca49cb