### PR TITLE
Use gpt-4o-mini model

### DIFF
--- a/src/components/dashboard/AIFlowModal.tsx
+++ b/src/components/dashboard/AIFlowModal.tsx
@@ -249,7 +249,7 @@ export default function AIFlowModal({ open, onOpenChange, onImport }: Props) {
           Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
         },
         body: JSON.stringify({
-          model: "gpt-4",
+          model: "gpt-4o-mini",
           messages: [
             { role: "system", content: SYSTEM_PROMPT },
             ...newMessages.map((m) => ({ role: m.role, content: m.content })),


### PR DESCRIPTION
## Summary
- update `AIFlowModal` to request `gpt-4o-mini` instead of `gpt-4`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ed1d3b15083228acd80f7d594442b