### PR TITLE
Fix toasts not showing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@
 import { StrictMode, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { Toaster } from "@/components/ui/toaster";
 
 import "./index.css";
 import { registerSW } from "virtual:pwa-register";
@@ -73,5 +74,6 @@ function App() {
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
+    <Toaster />
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- include `Toaster` component in the root render so toast messages are visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ed2ff0f5c8322abfa4bd6082e98e8