### PR TITLE
Add defense script and compile instructions for TCC

### DIFF
--- a/tcc_final/README.md
+++ b/tcc_final/README.md
@@ -1,0 +1,22 @@
+# TCC - TACO (Task Companion)
+
+Este diretório contém os arquivos em formato LaTeX e Markdown utilizados na monografia do aplicativo **TACO**. O documento principal é `main.tex`, que inclui cada seção individual.
+
+## Estrutura
+- `Introducao.md`, `Fundamentacao_Teorica.md`, `Metodologia.md`, `Desenvolvimento.md`, `Resultados.md`, `Iteracoes_V3.md`, `Conclusao.md` – capítulos em Markdown.
+- `resumo.tex` e `abstract.tex` – versões em português e inglês do resumo.
+- `corpo_extra.tex` – texto adicional gerado com `\lipsum` para completar o número de páginas.
+- `referencias.bib` – bibliografia.
+
+## Como compilar
+1. Certifique-se de ter uma distribuição LaTeX instalada (por exemplo, TeX Live).
+2. No terminal, execute:
+   ```bash
+   pdflatex main.tex
+   bibtex main
+   pdflatex main.tex
+   pdflatex main.tex
+   ```
+3. O arquivo `main.pdf` será gerado com o TCC completo.
+
+Caso não seja possível compilar nesta máquina, copie o diretório `tcc_final` para um ambiente que possua LaTeX disponível.

--- a/tcc_final/defesa_40min.md
+++ b/tcc_final/defesa_40min.md
@@ -1,0 +1,61 @@
+# Roteiro de Defesa de TCC (40 minutos)
+
+**Apresentador:** Ricardo Wildenberg
+
+---
+
+## 1. Introdução (4 minutos)
+- Cumprimentos e apresentação pessoal.
+- Contextualização do problema de treinamento e repetição de instruções.
+- Objetivo do trabalho: apresentar o TACO, um aplicativo web que padroniza fluxos de tarefas de forma interativa e offline.
+- Estrutura da apresentação.
+
+## 2. Motivação e Justificativa (4 minutos)
+- Relato da experiência profissional que inspirou o projeto.
+- Desafios de documentação dispersa e curva de aprendizado longa.
+- Potencial do TACO para agilizar o onboarding em diferentes setores.
+- Relevância de uma solução livre, acessível e que funcione sem internet.
+
+## 3. Fundamentação Teórica (5 minutos)
+- Conceitos de PWA e suas vantagens: funcionamento offline e instalação em múltiplos dispositivos.
+- IndexedDB e Dexie para armazenamento local seguro.
+- Modelagem de processos por grafos de transição.
+- Gamificação e feedback contínuo para manter o usuário engajado.
+- Interface reativa em React e Tailwind CSS.
+
+## 4. Metodologia (5 minutos)
+- Levantamento de requisitos com potenciais usuários.
+- Prototipação rápida e testes de usabilidade.
+- Desenvolvimento incremental com versionamento em Git.
+- Uso de bibliotecas como Playwright para testes automatizados.
+
+## 5. Arquitetura e Desenvolvimento (7 minutos)
+- Visão geral da estrutura do projeto.
+- Descrição do editor de fluxos e de seus tipos de passos.
+- Armazenamento e sincronização dos dados no navegador.
+- Registro de execuções e geração de métricas.
+- Possibilidade de personalização de componentes e identidade visual.
+
+## 6. Resultados (5 minutos)
+- Demonstração das telas principais do TACO.
+- Relato dos testes de usabilidade e desempenho.
+- Destaque para o baixo consumo de memória e resposta rápida.
+- Feedback de usuários que experimentaram as primeiras versões.
+
+## 7. Conclusão e Trabalhos Futuros (4 minutos)
+- Recapitulação dos objetivos alcançados.
+- Benefícios do modo offline e da rastreabilidade das tarefas.
+- Propostas de melhorias: integrações em nuvem e colaboração em tempo real.
+- Impacto esperado na produtividade de equipes.
+
+## 8. Sessão de Perguntas (6 minutos)
+- Orientar a banca a respeito do tempo de perguntas.
+- Estimular questionamentos sobre o funcionamento do app e sobre as decisões de projeto.
+
+## 9. Encerramento (1 minuto)
+- Agradecimentos ao orientador, colegas e banca.
+- Convidar para testes práticos do TACO após a sessão.
+
+---
+
+Tempo total aproximado: **40 minutos**.


### PR DESCRIPTION
## Summary
- provide instructions for compiling the final TCC
- add a detailed 40-minute defense outline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687979e916f88322bee763a25a8dac6c