### PR TITLE
Fix TypeScript errors and imports

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,4 +1,3 @@
-import type React from "react";
 import { parseMarkdown } from "../utils/markdown";
 
 interface Props {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,6 @@ import { NavLink } from "react-router-dom";
 import {
   Home,
   Activity,
-  FileText,
   User,
   Menu,
   Settings as SettingsIcon,

--- a/src/components/dashboard/AIFlowModal.tsx
+++ b/src/components/dashboard/AIFlowModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type React from "react";
-
 import { useState, useRef, useEffect } from "react";
 import {
   Dialog,
@@ -421,7 +420,7 @@ export default function AIFlowModal({ open, onOpenChange, onImport }: Props) {
                             className,
                             children,
                             ...props
-                          }) {
+                          }: any) {
                             const match = /language-(\w+)/.exec(
                               className || ""
                             );
@@ -451,7 +450,7 @@ export default function AIFlowModal({ open, onOpenChange, onImport }: Props) {
                                     </Button>
                                   </div>
                                   <SyntaxHighlighter
-                                    style={oneDark}
+                                    style={oneDark as { [key: string]: React.CSSProperties }}
                                     language={match[1]}
                                     PreTag="div"
                                     className="!mt-0 !rounded-t-none"

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -20,12 +20,6 @@ function genId() {
   return count.toString();
 }
 
-type ActionType =
-  | "ADD_TOAST"
-  | "UPDATE_TOAST"
-  | "DISMISS_TOAST"
-  | "REMOVE_TOAST";
-
 type Action =
   | {
       type: "ADD_TOAST";

--- a/src/hooks/useAnalyticsConfig.ts
+++ b/src/hooks/useAnalyticsConfig.ts
@@ -10,7 +10,7 @@ interface AnalyticsConfigStore {
 
 export const useAnalyticsConfig = create<AnalyticsConfigStore>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       runsToShow: 5,
       customOptions: [],
       setRunsToShow: (v) => set({ runsToShow: v }),

--- a/src/hooks/useFlows.ts
+++ b/src/hooks/useFlows.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { nanoid } from "nanoid";
-import type { Flow, Step, FlowPackage, CustomComponent } from "../types/flow";
+import type { Flow, FlowPackage, CustomComponent } from "../types/flow";
 import { buildNetworkGraph } from "../utils/graph";
 import { db } from "../db";
 import { logAction } from "../utils/audit";

--- a/src/pages/Analytics/AnalyticsHeader.tsx
+++ b/src/pages/Analytics/AnalyticsHeader.tsx
@@ -214,10 +214,7 @@ export default function AnalyticsHeader({
             <div
               className={cn(
                 "space-y-3 sm:space-y-0 sm:flex sm:items-center sm:space-x-3",
-                {
-                  "hidden sm:flex": !showMobileFilters,
-                  block: showMobileFilters,
-                }
+                !showMobileFilters ? "hidden sm:flex" : "block"
               )}
             >
               {/* Select Filter */}

--- a/src/pages/Analytics/PerformanceInsights.tsx
+++ b/src/pages/Analytics/PerformanceInsights.tsx
@@ -58,11 +58,6 @@ export default function PerformanceInsights({
           insights.totalSessions) *
         100
       : 0;
-  const efficiency =
-    insights.averageCompletionTime > 0
-      ? insights.successfulSessions / insights.averageCompletionTime
-      : 0;
-
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 print:break-inside-avoid">
       {/* Performance Overview */}

--- a/src/pages/Analytics/StackedAreaChart.tsx
+++ b/src/pages/Analytics/StackedAreaChart.tsx
@@ -89,6 +89,7 @@ export default function StackedAreaChart({
                   backgroundColor: "rgba(255, 255, 255, 0.95)",
                 }}
               />
+              {/* @ts-expect-error payload prop not in type definitions */}
               <Legend
                 verticalAlign="bottom"
                 align="center"

--- a/src/pages/Analytics/TimelineChart.tsx
+++ b/src/pages/Analytics/TimelineChart.tsx
@@ -80,6 +80,7 @@ export default function TimelineChart({ data, steps, colors, runsToShow }: Props
                   border: "1px solid #e2e8f0",
                 }}
               />
+              {/* @ts-expect-error payload prop not in type definitions */}
               <Legend
                 verticalAlign="bottom"
                 align="center"

--- a/src/pages/Company.tsx
+++ b/src/pages/Company.tsx
@@ -1,4 +1,5 @@
-import { useRef, ChangeEvent } from "react";
+import { useRef } from "react";
+import type { ChangeEvent } from "react";
 import SidebarLayout from "../components/Sidebar";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -17,10 +17,6 @@ import {
   X,
   Check,
   MoreVertical,
-  Play,
-  BarChart3,
-  Edit,
-  Copy,
 } from "lucide-react"
 
 import {

--- a/src/pages/FlowEditor/StepForm/Text.tsx
+++ b/src/pages/FlowEditor/StepForm/Text.tsx
@@ -1,6 +1,4 @@
-import type { Step } from "../../../types/flow";
-
-export default function TextStepForm({ step }: { step: Step }) {
+export default function TextStepForm() {
   // Texto não possui campos adicionais além dos básicos
   return null;
 }


### PR DESCRIPTION
## Summary
- remove unused imports from components and hooks
- adjust `cn` usage for Analytics header
- clean up unused variables
- mark Recharts legend payload props with TS ignore comment
- fix type-only imports

## Testing
- `npm run build` *(fails: Cannot find type definition file for various packages)*

------
https://chatgpt.com/codex/tasks/task_e_687b1f4df2d083228080584523af9b0b