### PR TITLE
Fix Legend typings

### DIFF
--- a/src/pages/Analytics/StackedAreaChart.tsx
+++ b/src/pages/Analytics/StackedAreaChart.tsx
@@ -98,14 +98,6 @@ export default function StackedAreaChart({
                 }}
                 iconSize={isMobile ? 8 : 12}
                 layout="horizontal"
-                payload={
-                  steps.map((step, idx) => ({
-                    value: step.title,
-                    type: "rect",
-                    color: colors[idx % colors.length],
-                    payload: { dataKey: step.id },
-                  })) as any
-                }
               />
               {steps.map((step, idx) => (
                 <Area

--- a/src/pages/Analytics/TimelineChart.tsx
+++ b/src/pages/Analytics/TimelineChart.tsx
@@ -94,14 +94,6 @@ export default function TimelineChart({
                 }}
                 iconSize={isMobile ? 8 : 12}
                 layout={isMobile ? "horizontal" : "horizontal"}
-                payload={
-                  steps.map((step, idx) => ({
-                    value: step.title,
-                    type: "rect",
-                    color: colors[idx % colors.length],
-                    payload: { dataKey: step.id },
-                  })) as any
-                }
               />
               {steps.map((step, idx) => (
                 <Bar


### PR DESCRIPTION
## Summary
- remove unsupported `payload` prop in stacked and timeline charts

## Testing
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687b26cb55e08322b67a2eb6718b9ed2