### PR TITLE
Fix SidebarLayout title font size for mobile

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -68,7 +68,7 @@ export default function SidebarLayout({ title, children }: SidebarLayoutProps) {
 
       <div className="lg:hidden fixed top-0 left-0 right-0 z-50 bg-white border-b">
         <div className="flex items-center justify-between p-4">
-          <h1 className="font-semibold">{title}</h1>
+          <h1 className="font-semibold text-lg sm:text-xl">{title}</h1>
           <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
             <SheetTrigger asChild>
               <Button variant="outline" size="sm">


### PR DESCRIPTION
## Summary
- make SidebarLayout title text responsive so it scales better on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e312d401c832287ad019263cb17aa