### PR TITLE
feat: add mock analytics data

### DIFF
--- a/src/mocks/mockAnalyticsData.ts
+++ b/src/mocks/mockAnalyticsData.ts
@@ -1,0 +1,78 @@
+import type { Flow, Session, PathItem } from "@/types/flow";
+import type { AnalyticsData } from "@/hooks/useAnalytics";
+
+// Define the flow used in analytics mock
+export const mockFlow: Flow = {
+  id: "mock-flow",
+  title: "Integração de Novo Funcionário (mock)",
+  status: "DRAFT",
+  steps: [
+    { id: "step1", order: 1, type: "TEXT", title: "Preparar computador", content: "" },
+    { id: "step2", order: 2, type: "TEXT", title: "Instalar IDE", content: "" },
+    { id: "step3", order: 3, type: "TEXT", title: "Programador?", content: "" },
+    { id: "step4", order: 4, type: "TEXT", title: "Acesso de Admin", content: "" },
+    { id: "step5", order: 5, type: "TEXT", title: "Configuração da VPN", content: "" },
+    { id: "step6", order: 6, type: "TEXT", title: "Instruções de Segurança", content: "" },
+    { id: "step7", order: 7, type: "TEXT", title: "Teste Técnico", content: "" },
+    { id: "step8", order: 8, type: "TEXT", title: "Reunião com a equipe", content: "" },
+    { id: "step9", order: 9, type: "TEXT", title: "Reunião com PO", content: "" },
+    { id: "step10", order: 10, type: "TEXT", title: "Enviar Documentos", content: "" },
+    { id: "step11", order: 11, type: "TEXT", title: "Enviar Áudio", content: "" },
+    { id: "step12", order: 12, type: "TEXT", title: "Enviar PDF", content: "" },
+  ],
+  networkGraph: [],
+  visits: 10,
+  completions: 8,
+  updatedAt: Date.now(),
+};
+
+// Base durations for each step in minutes
+const baseDurations = [5, 30, 2, 15, 80, 5, 3, 10, 25, 15, 5, 2];
+const stepIds = mockFlow.steps.map((s) => s.id);
+const stepTitles = mockFlow.steps.map((s) => s.title);
+
+// Generate 10 sessions with durations ranging from minutes to hours
+export const mockSessions: Session[] = Array.from({ length: 10 }, (_, idx) => {
+  const factor = 0.5 + idx * 0.15; // increases duration each session
+  const path: PathItem[] = stepIds.map((id, i) => ({
+    id,
+    title: stepTitles[i],
+    timeSpent: baseDurations[i] * factor * 60_000, // convert to ms
+  }));
+  const total = path.reduce((sum, p) => sum + p.timeSpent, 0);
+  const startedAt = Date.now() - (10 - idx) * 60 * 60_000; // sessions spaced an hour apart
+  return {
+    id: `session${idx + 1}`,
+    flowId: mockFlow.id,
+    startedAt,
+    finishedAt: startedAt + total,
+    currentIndex: -1,
+    path,
+  } as Session;
+});
+
+export function computeMockAnalytics(): AnalyticsData {
+  const visits = mockFlow.visits;
+  const completions = mockFlow.completions;
+  const completionRate = visits === 0 ? 0 : completions / visits;
+
+  const stepTimeAgg: Record<string, number[]> = {};
+  mockSessions.forEach((s) => {
+    s.path.forEach((p) => {
+      if (!stepTimeAgg[p.id]) stepTimeAgg[p.id] = [];
+      stepTimeAgg[p.id].push(p.timeSpent);
+    });
+  });
+
+  const avgTimePerStep = Object.entries(stepTimeAgg).map(([stepId, times]) => ({
+    stepId,
+    avgTime: times.reduce((a, b) => a + b, 0) / times.length,
+  }));
+
+  const totalTimePerStep = Object.entries(stepTimeAgg).map(([stepId, times]) => ({
+    stepId,
+    totalTime: times.reduce((a, b) => a + b, 0),
+  }));
+
+  return { visits, completions, completionRate, avgTimePerStep, totalTimePerStep };
+}

--- a/src/pages/Analytics/index.tsx
+++ b/src/pages/Analytics/index.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { useFlows } from "@/hooks/useFlows";
-import type { Flow, PathItem, Session } from "@/types/flow";
+import type { Flow, PathItem } from "@/types/flow";
 import { useAnalyticsConfig } from "@/hooks/useAnalyticsConfig";
-import { useAnalytics } from "@/hooks/useAnalytics";
-import { db } from "@/db";
+import {
+  mockFlow,
+  mockSessions,
+  computeMockAnalytics,
+} from "@/mocks/mockAnalyticsData";
 import AnalyticsHeader from "./AnalyticsHeader";
 import TotalTimeChart from "./TotalTimeChart";
 import TimelineChart from "./TimelineChart";
@@ -30,8 +31,6 @@ interface SessionRun {
 }
 
 export default function Analytics() {
-  const { id = "" } = useParams<{ id: string }>();
-  const { flows, load, update } = useFlows();
   const { runsToShow, customOptions, setRunsToShow, addCustomOption } =
     useAnalyticsConfig();
   const [newOption, setNewOption] = useState("");
@@ -40,74 +39,44 @@ export default function Analytics() {
     { name: string; totalTime: number; color: string }[]
   >([]);
 
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const flow = flows.find((f) => f.id === id);
-  const stats = useAnalytics(flow ?? undefined);
+  const flow: Flow = mockFlow;
+  const stats = computeMockAnalytics();
 
   useEffect(() => {
-    if (!flow || !stats) return;
-    (async () => {
-      const all: Session[] = await db.sessions
-        .where("flowId")
-        .equals(flow.id)
-        .toArray();
-      const sorted = all.sort((a, b) => b.startedAt - a.startedAt);
-      const limit = runsToShow === "all" ? sorted.length : runsToShow;
-      const lastRuns = sorted.slice(0, limit);
-      setRecentRuns(
-        lastRuns.map((s) => ({
-          sessionId: s.id,
-          startedAt: s.startedAt,
-          path: Array.isArray(s.path) ? s.path : [],
-        }))
-      );
-    })();
-  }, [flow, stats, runsToShow]);
+    const sorted = [...mockSessions].sort((a, b) => b.startedAt - a.startedAt);
+    const limit = runsToShow === "all" ? sorted.length : runsToShow;
+    const lastRuns = sorted.slice(0, limit);
+    setRecentRuns(
+      lastRuns.map((s) => ({
+        sessionId: s.id,
+        startedAt: s.startedAt,
+        path: Array.isArray(s.path) ? s.path : [],
+      }))
+    );
+  }, [runsToShow]);
 
   useEffect(() => {
-    if (!flow) return;
-    (async () => {
-      const all: Session[] = await db.sessions
-        .where("flowId")
-        .equals(flow.id)
-        .toArray();
-      const agg: Record<string, number> = {};
-      all.forEach((s) => {
-        if (Array.isArray(s.path)) {
-          s.path.forEach((p: PathItem) => {
-            agg[p.id] = (agg[p.id] || 0) + p.timeSpent;
-          });
-        }
-      });
-      const arr = flow.steps.map((step, idx) => ({
-        name: step.title,
-        totalTime: +(agg[step.id] || 0) / 1000,
-        color: COLORS[idx % COLORS.length],
-      }));
-      setTotalByStepData(arr);
-    })();
+    const agg: Record<string, number> = {};
+    mockSessions.forEach((s) => {
+      if (Array.isArray(s.path)) {
+        s.path.forEach((p: PathItem) => {
+          agg[p.id] = (agg[p.id] || 0) + p.timeSpent;
+        });
+      }
+    });
+    const arr = flow.steps.map((step, idx) => ({
+      name: step.title,
+      totalTime: +(agg[step.id] || 0) / 1000,
+      color: COLORS[idx % COLORS.length],
+    }));
+    setTotalByStepData(arr);
   }, [flow]);
-
-  if (!flow) return <p className="p-6">Carregando analytics…</p>;
-  if (!stats) return <p className="p-6">Carregando métricas…</p>;
 
   const f: Flow = flow;
   const st = stats;
 
-  async function handleClear() {
-    if (!window.confirm("Deseja limpar todas as métricas deste fluxo?")) return;
-    const sessions = await db.sessions.where("flowId").equals(f.id).toArray();
-    const ids = sessions.map((s) => s.id);
-    if (ids.length) {
-      await db.stepEvents.where("sessionId").anyOf(ids).delete();
-      await db.sessions.where("flowId").equals(f.id).delete();
-    }
-    update({ ...f, visits: 0, completions: 0 });
-    setRecentRuns([]);
-    setTotalByStepData([]);
+  function handleClear() {
+    alert("Dados de demonstração não podem ser limpos.");
   }
 
   const handleAddCustomOption = () => {


### PR DESCRIPTION
## Summary
- add reusable mock flow and session data for analytics
- switch analytics screen to consume mock dataset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 15 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6892c769ad3883229a28df8f9d85ff52