### PR TITLE
Remove import suffix from imported flows

### DIFF
--- a/src/hooks/useFlows.ts
+++ b/src/hooks/useFlows.ts
@@ -256,7 +256,7 @@ export const useFlows = create<FlowStore>()(
             const flow: Flow = {
               ...f,
               id: newId,
-              title: `${f.title} (importado)`,
+              title: f.title,
               status: "DRAFT",
               visits: 0,
               completions: 0,


### PR DESCRIPTION
## Summary
- avoid appending "(importado)" to imported flow titles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected 'debugger' statement, Unexpected any, Fast refresh only works when a file has exports, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68ade0d2055c832281adf974f90d628a