### PR TITLE
feat: switch default AI model to gpt-5-mini

### DIFF
--- a/docs/ai-setup.md
+++ b/docs/ai-setup.md
@@ -1,16 +1,16 @@
-# Configuração da IA - OpenAI GPT-4o Mini
+# Configuração da IA - OpenAI GPT-5 Mini
 
 Este documento explica como configurar e usar a integração com a **OpenAI** no Task Companion.
 
 ## Visão Geral
 
-O assistente utiliza a família de modelos **GPT-4o** para:
+O assistente utiliza por padrão o modelo **GPT-5 Mini** para:
 
 - Criar fluxos interativos com base em descrições em linguagem natural
 - Sugerir ajustes nos passos antes da geração do JSON final
 - Gerar automaticamente um JSON válido para importação
 
-O modelo padrão é o `gpt-4o-mini`, otimizado para respostas rápidas com ótimo custo-benefício. Se ele não estiver disponível, o sistema tenta outros modelos compatíveis automaticamente.
+O modelo padrão é o `gpt-5-mini`, otimizado para respostas rápidas com ótimo custo-benefício. Se ele não estiver disponível, o sistema tenta outros modelos compatíveis automaticamente, priorizando a família **GPT-4o**.
 
 ## Configuração
 
@@ -51,10 +51,11 @@ if (AI_CONFIG.isConfigured) {
 
 | Ordem | Modelo         | Uso recomendado                              |
 |-------|----------------|----------------------------------------------|
-| 1     | `gpt-4o-mini`  | Respostas rápidas e econômicas               |
-| 2     | `gpt-4.1-mini` | Alternativa estável com mesmo estilo         |
-| 3     | `gpt-4o`       | Respostas mais ricas em contexto multimodal  |
-| 4     | `gpt-4.1`      | Respostas extensas e de alta precisão        |
+| 1     | `gpt-5-mini`   | Respostas rápidas e econômicas               |
+| 2     | `gpt-4o-mini`  | Alternativa ágil dentro da família GPT-4o    |
+| 3     | `gpt-4.1-mini` | Alternativa estável com mesmo estilo         |
+| 4     | `gpt-4o`       | Respostas mais ricas em contexto multimodal  |
+| 5     | `gpt-4.1`      | Respostas extensas e de alta precisão        |
 
 O fallback é realizado automaticamente seguindo a ordem acima.
 

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -5,7 +5,7 @@
  */
 export const AI_CONFIG = {
   // Modelo de IA a ser utilizado (com fallback automático)
-  MODEL: "gpt-4o-mini",
+  MODEL: "gpt-5-mini",
 
   // Base da API OpenAI
   API_BASE_URL: "https://api.openai.com/v1",
@@ -97,6 +97,7 @@ export const AI_CONFIG = {
  * Tipos de modelos disponíveis
  */
 export const AI_MODELS = {
+  GPT_5_MINI: "gpt-5-mini",
   GPT_4O_MINI: "gpt-4o-mini",
   GPT_41_MINI: "gpt-4.1-mini",
   GPT_4O: "gpt-4o",
@@ -109,6 +110,7 @@ export type AIModel = (typeof AI_MODELS)[keyof typeof AI_MODELS];
  * Lista de modelos em ordem de preferência (fallback automático)
  */
 export const MODEL_FALLBACK_ORDER = [
+  AI_MODELS.GPT_5_MINI,
   AI_MODELS.GPT_4O_MINI,
   AI_MODELS.GPT_41_MINI,
   AI_MODELS.GPT_4O,
@@ -182,7 +184,7 @@ export async function getAvailableModel(): Promise<string> {
     }
   }
 
-  // Fallback final para o modelo flash 1.5
+  // Fallback final para o modelo gpt-4o
   console.log("⚠️ Usando gpt-4o como fallback");
   return AI_MODELS.GPT_4O;
 }


### PR DESCRIPTION
## Summary
- set the default OpenAI model configuration to gpt-5-mini and add it to the fallback chain
- document the new default model and updated priority order in the AI setup guide

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e26db53408320941901285c4d45c1)